### PR TITLE
Use OMOQ_SYNC_TOKEN for upstream sync push

### DIFF
--- a/.github/workflows/openmoq-upstream-sync.yml
+++ b/.github/workflows/openmoq-upstream-sync.yml
@@ -12,16 +12,18 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  workflows: write      # needed to push upstream changes to .github/workflows/
 
 jobs:
   sync:
     runs-on: ubuntu-22.04
     steps:
+      # PAT with 'workflow' scope required to push upstream changes to
+      # .github/workflows/ files. GITHUB_TOKEN cannot modify workflow files.
+      # Falls back to GITHUB_TOKEN if SYNC_PAT is not configured.
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.OMOQ_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
 
       # ── Step 1: Check upstream for qualifying changes ──
       - name: Check upstream status


### PR DESCRIPTION
## Summary
- Use `OMOQ_SYNC_TOKEN` secret (PAT with `workflow` scope) for checkout/push
- `GITHUB_TOKEN` cannot push changes to `.github/workflows/` files
- Falls back to `GITHUB_TOKEN` if token not configured

Pending org approval of the fine-grained PAT.