### PR TITLE
Use PAT for sync PR creation and auto-merge

### DIFF
--- a/.github/workflows/openmoq-upstream-sync.yml
+++ b/.github/workflows/openmoq-upstream-sync.yml
@@ -202,7 +202,7 @@ jobs:
         if: steps.upstream.outputs.should_sync == 'true'
         id: pr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.OMOQ_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           BRANCH="sync-upstream-${{ steps.upstream.outputs.short_sha }}"
           UPSTREAM_SHA="${{ steps.upstream.outputs.upstream_sha }}"
@@ -245,7 +245,7 @@ jobs:
       - name: Enable auto-merge
         if: steps.upstream.outputs.should_sync == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.OMOQ_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           BRANCH="sync-upstream-${{ steps.upstream.outputs.short_sha }}"
           PR_NUM=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number')


### PR DESCRIPTION
GITHUB_TOKEN lacks org-level permission to create PRs. Use OMOQ_SYNC_TOKEN
(which has pull-requests:write) for the `gh pr create` and `gh pr merge` steps.

Fixes the `Resource not accessible by integration (createPullRequest)` error
from the last upstream sync run.