### PR TITLE
Reduce folly's deps and use a minimal boost

### DIFF
--- a/build/fbcode_builder/manifests/boost-minimal
+++ b/build/fbcode_builder/manifests/boost-minimal
@@ -1,0 +1,55 @@
+[manifest]
+name = boost-minimal
+
+[download.not(os=windows)]
+url = https://archives.boost.io/release/1.83.0/source/boost_1_83_0.tar.gz
+sha256 = c0685b68dd44cc46574cce86c4e17c0f611b15e195be9848dfd0769a0a207628
+
+[download.os=windows]
+url = https://archives.boost.io/release/1.83.0/source/boost_1_83_0.zip
+sha256 = c86bd9d9eef795b4b0d3802279419fde5221922805b073b9bd822edecb1ca28e
+
+[preinstalled.env]
+BOOST_ROOT_1_69_0
+BOOST_ROOT_1_83_0
+
+[debs]
+libboost-context-dev
+libboost-regex-dev
+libboost-filesystem-dev
+libboost-program-options-dev
+libboost-thread-dev
+
+[homebrew]
+boost
+icu4c
+
+[pps]
+boost
+
+[rpms.distro=fedora]
+boost-devel
+
+[build]
+builder = boost
+job_weight_mib = 512
+
+[b2.args]
+--with-context
+--with-regex
+--with-filesystem
+--with-program_options
+--with-thread
+
+[bootstrap.args.os=darwin]
+--with-toolset=gcc
+
+[b2.args.os=linux]
+pch=off
+
+[b2.args.os=darwin]
+toolset=clang
+cxxflags="-DBOOST_UNORDERED_HAVE_PIECEWISE_CONSTRUCT=0"
+
+[b2.args.all(os=windows,fb=on)]
+toolset=msvc-14.3

--- a/build/fbcode_builder/manifests/folly
+++ b/build/fbcode_builder/manifests/folly
@@ -15,16 +15,12 @@ job_weight_mib = 1024
 gflags
 glog
 googletest
-boost
+boost-minimal
 libdwarf
 libevent
-libsodium
 double-conversion
 fast_float
 fmt
-lz4
-snappy
-zstd
 # no openssl or zlib in the linux case, why?
 # these are usually installed on the system
 # and are the easiest system deps to pull in.
@@ -45,14 +41,11 @@ openssl
 zlib
 
 [dependencies.os=linux]
-libaio
-libiberty
 libunwind
 
 # xz depends on autoconf which does not build on
 # Windows
 [dependencies.not(os=windows)]
-xz
 
 [shipit.pathmap]
 fbcode/folly/public_tld = .


### PR DESCRIPTION
This is a totally functional set of deps for our current purposes.  Note that dwarf and unwind are also removable, but they provide some nice debugging functionality if you install the folly crash signal handler.

zstd is still required by fizz and proxygen (for now) so it's still part of the build.

We could maybe remove thread from folly -- it's only needed for the windows build.  Other compiled boost deps are in the process of being made optional.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/15)
<!-- Reviewable:end -->
