### PR TITLE
Fix publish-artifacts: size, container paths, local scripts

### DIFF
--- a/.github/workflows/openmoq-publish-artifacts.yml
+++ b/.github/workflows/openmoq-publish-artifacts.yml
@@ -57,7 +57,8 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends \
             build-essential python3 curl git ca-certificates \
-            pkg-config libssl-dev m4 autoconf automake libtool
+            pkg-config libssl-dev m4 autoconf automake libtool \
+            binutils
 
       - name: Install system deps (Ubuntu runner)
         if: matrix.container == '' && runner.os == 'Linux'
@@ -87,44 +88,21 @@ jobs:
             --extra-cmake-defines '{"CMAKE_FIND_LIBRARY_SUFFIXES": ".a", "BUILD_SHARED_LIBS": "OFF"}' \
             moxygen
 
-      - name: Collect installed artifacts
-        id: collect
+      # Use the collect-artifacts script instead of inline logic.
+      # Writes tarball to $GITHUB_WORKSPACE/ so it's accessible from both
+      # the container and the host (fixes bookworm upload-artifact path issue).
+      - name: Collect and package artifacts
         run: |
-          SCRATCH="${{ runner.temp }}/moxygen-scratch"
-
-          # Get all install directories (moxygen + transitive deps)
-          python3 build/fbcode_builder/getdeps.py \
-            show-inst-dir \
-            --scratch-path "$SCRATCH" \
-            --extra-cmake-defines '{"CMAKE_FIND_LIBRARY_SUFFIXES": ".a", "BUILD_SHARED_LIBS": "OFF"}' \
-            --recursive moxygen 2>/dev/null \
-            | grep "^/" > "${{ runner.temp }}/inst-dirs.txt"
-
-          # Create a staging directory with all artifacts
-          STAGE="${{ runner.temp }}/artifact-stage"
-          mkdir -p "$STAGE"
-
-          while IFS= read -r dir; do
-            if [ -d "$dir" ]; then
-              cp -a "$dir/." "$STAGE/"
-            fi
-          done < "${{ runner.temp }}/inst-dirs.txt"
-
-          # Also save the cmake_prefix_path for consumers
-          cat "${{ runner.temp }}/inst-dirs.txt" | tr '\n' ';' > "$STAGE/cmake_prefix_path.txt"
-
-          echo "stage=$STAGE" >> "$GITHUB_OUTPUT"
-
-      - name: Create tarball
-        run: |
-          cd "${{ steps.collect.outputs.stage }}"
-          tar czf "${{ runner.temp }}/${{ matrix.artifact }}" .
+          bash openmoq/scripts/collect-artifacts.sh \
+            --scratch-path "${{ runner.temp }}/moxygen-scratch" \
+            --output "$GITHUB_WORKSPACE/${{ matrix.artifact }}" \
+            --src-dir .
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: ${{ runner.temp }}/${{ matrix.artifact }}
+          path: ${{ github.workspace }}/${{ matrix.artifact }}
           retention-days: 90
 
   # ──────────────────────────────────────────────────────────────
@@ -141,57 +119,14 @@ jobs:
         with:
           path: artifacts/
 
-      - name: Create release
+      - name: Create release and prune old builds
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          SHORT_SHA="${GITHUB_SHA:0:12}"
-          TAG="build-${SHORT_SHA}"
-
-          # Delete existing release with this tag if it exists (idempotent)
-          gh release delete "$TAG" --yes 2>/dev/null || true
-          git tag -d "$TAG" 2>/dev/null || true
-          git push origin ":refs/tags/$TAG" 2>/dev/null || true
-
-          # Flatten artifacts (download-artifact creates subdirs per artifact name)
-          mkdir -p release-assets/
-          find artifacts/ -name '*.tar.gz' -exec cp {} release-assets/ \;
-
-          # Create the release
-          gh release create "$TAG" \
-            --title "Build artifacts for ${SHORT_SHA}" \
-            --notes "$(cat <<EOF
-          Automated build artifacts for commit \`${SHORT_SHA}\`.
-
-          These bundles contain moxygen and all transitive Meta dependencies
-          (folly, fizz, wangle, mvfst, proxygen) as static libraries with
-          headers and CMake config files.
-
-          **Usage in o-rly CI:**
-          \`\`\`bash
-          gh release download "${TAG}" --repo openmoq/moxygen \\
-            --pattern "moxygen-<platform>.tar.gz" --dir .scratch/
-          tar xzf .scratch/moxygen-*.tar.gz -C .scratch/
-          \`\`\`
-          EOF
-          )" \
-            release-assets/*.tar.gz
-
-          echo "Release created: $TAG"
-
-      - name: Prune old build releases
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          KEEP=20
-          gh release list --limit 100 \
-            | grep '^build-' \
-            | tail -n +$((KEEP + 1)) \
-            | awk '{print $1}' \
-            | while read -r tag; do
-                echo "Deleting old release: $tag"
-                gh release delete "$tag" --yes --cleanup-tag
-              done
+          bash openmoq/scripts/create-release.sh \
+            --artifacts-dir artifacts/ \
+            --sha "$GITHUB_SHA" \
+            --keep 20
 
       # ── Notifications ──
       - name: Notify Slack

--- a/openmoq/README.md
+++ b/openmoq/README.md
@@ -8,6 +8,8 @@ This directory contains OpenMOQ-specific files that are not part of the upstream
 - **`patches/`** — Ordered patch files applied during upstream sync. Named with
   numeric prefixes for application order (e.g., `001-libaio-source-build.patch`).
   Applied sequentially via `git am` in the `openmoq-upstream-sync` workflow.
+- **`scripts/`** — Build and CI scripts extracted from workflows for local testing.
+  See [Scripts](#scripts) below.
 
 ## Workflow Files
 
@@ -65,6 +67,41 @@ that would otherwise be overwritten on each sync.
   overwritten on the next upstream sync.
 - **Direct changes** — for OpenMOQ-owned files (`openmoq/`, `.github/workflows/openmoq-*.yml`,
   `docker/` Dockerfiles) that are not overwritten by upstream syncs.
+
+## Scripts
+
+### `openmoq/scripts/collect-artifacts.sh`
+
+Collects getdeps install directories into a release tarball. Extracted from the
+`openmoq-publish-artifacts.yml` workflow so it can be tested locally.
+
+**What it does:**
+- Queries `getdeps.py show-inst-dir --recursive` for all install dirs
+- Excludes build-tool dependencies (ninja, cmake, autoconf, automake, libtool, gperf)
+- Strips debug symbols from static libraries (`.a`) and shared objects (`.so`)
+- On Linux: saves `.debug` sidecar files in `.debug/` subdirectories with GNU debuglink
+- Reports before/after sizes and fails if the tarball exceeds the 2 GiB GitHub Release limit
+
+```bash
+# Local testing (requires a getdeps scratch dir from a previous build)
+openmoq/scripts/collect-artifacts.sh \
+  --scratch-path /tmp/moxygen-scratch \
+  --output /tmp/test-artifact.tar.gz \
+  --src-dir .
+```
+
+### `openmoq/scripts/create-release.sh`
+
+Creates a GitHub Release from artifact tarballs and prunes old releases.
+
+```bash
+# Local testing (with --dry-run)
+openmoq/scripts/create-release.sh \
+  --artifacts-dir ./my-artifacts \
+  --sha "$(git rev-parse HEAD)" \
+  --keep 20 \
+  --dry-run
+```
 
 ## Building Moxygen
 

--- a/openmoq/scripts/collect-artifacts.sh
+++ b/openmoq/scripts/collect-artifacts.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# collect-artifacts.sh — Collect getdeps install dirs into a release tarball.
+#
+# Filters out build-tool-only dependencies, strips debug symbols (keeping
+# .debug sidecar files on Linux), and produces a compressed tarball suitable
+# for upload as a GitHub Release asset.
+#
+# Usage:
+#   collect-artifacts.sh \
+#     --scratch-path /path/to/moxygen-scratch \
+#     --output /path/to/moxygen-platform.tar.gz \
+#     --src-dir /path/to/moxygen-source
+#
+# Can be tested locally against any getdeps scratch directory.
+
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+
+SCRATCH_PATH=""
+OUTPUT=""
+SRC_DIR=""
+
+# Build tools that consumers never need. These are only used during the
+# getdeps build itself and are not link-time or runtime dependencies.
+EXCLUDE_DEPS="ninja cmake autoconf automake libtool gperf"
+
+# ── Argument parsing ─────────────────────────────────────────────────────────
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --scratch-path DIR --output FILE --src-dir DIR
+
+Options:
+  --scratch-path DIR   Path to the getdeps scratch directory
+  --output FILE        Output tarball path (must end in .tar.gz)
+  --src-dir DIR        Path to the moxygen source tree (for running getdeps.py)
+  --exclude DEPS       Space-separated list of dep names to exclude
+                       (default: "$EXCLUDE_DEPS")
+  -h, --help           Show this help
+EOF
+  exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --scratch-path) SCRATCH_PATH="$2"; shift 2 ;;
+    --output)       OUTPUT="$2"; shift 2 ;;
+    --src-dir)      SRC_DIR="$2"; shift 2 ;;
+    --exclude)      EXCLUDE_DEPS="$2"; shift 2 ;;
+    -h|--help)      usage 0 ;;
+    *)              echo "Unknown option: $1" >&2; usage 1 ;;
+  esac
+done
+
+if [[ -z "$SCRATCH_PATH" || -z "$OUTPUT" || -z "$SRC_DIR" ]]; then
+  echo "Error: --scratch-path, --output, and --src-dir are all required." >&2
+  usage 1
+fi
+
+if [[ ! -d "$SCRATCH_PATH" ]]; then
+  echo "Error: scratch path does not exist: $SCRATCH_PATH" >&2
+  exit 1
+fi
+
+GETDEPS="$SRC_DIR/build/fbcode_builder/getdeps.py"
+if [[ ! -f "$GETDEPS" ]]; then
+  echo "Error: getdeps.py not found at: $GETDEPS" >&2
+  exit 1
+fi
+
+# ── Step 1: Get install directories ──────────────────────────────────────────
+
+echo "==> Querying install directories from getdeps..."
+
+INST_DIRS_FILE=$(mktemp)
+trap 'rm -f "$INST_DIRS_FILE"' EXIT
+
+python3 "$GETDEPS" \
+  show-inst-dir \
+  --scratch-path "$SCRATCH_PATH" \
+  --extra-cmake-defines '{"CMAKE_FIND_LIBRARY_SUFFIXES": ".a", "BUILD_SHARED_LIBS": "OFF"}' \
+  --recursive moxygen 2>/dev/null \
+  | grep "^/" > "$INST_DIRS_FILE"
+
+TOTAL_DIRS=$(wc -l < "$INST_DIRS_FILE")
+echo "    Found $TOTAL_DIRS install directories"
+
+# ── Step 2: Filter out build tools ───────────────────────────────────────────
+
+echo "==> Filtering out build-tool dependencies: $EXCLUDE_DEPS"
+
+FILTERED_FILE=$(mktemp)
+trap 'rm -f "$INST_DIRS_FILE" "$FILTERED_FILE"' EXIT
+
+# Build a grep pattern that matches install dir names for each build tool.
+# getdeps names dirs as <name>-<hash>, e.g. /installed/cmake-oJhduB4y...
+EXCLUDE_PATTERN=""
+for dep in $EXCLUDE_DEPS; do
+  if [[ -n "$EXCLUDE_PATTERN" ]]; then
+    EXCLUDE_PATTERN="$EXCLUDE_PATTERN|"
+  fi
+  EXCLUDE_PATTERN="${EXCLUDE_PATTERN}/installed/${dep}(-|$)"
+done
+
+if [[ -n "$EXCLUDE_PATTERN" ]]; then
+  grep -vE "$EXCLUDE_PATTERN" "$INST_DIRS_FILE" > "$FILTERED_FILE" || true
+else
+  cp "$INST_DIRS_FILE" "$FILTERED_FILE"
+fi
+
+KEPT_DIRS=$(wc -l < "$FILTERED_FILE")
+EXCLUDED=$((TOTAL_DIRS - KEPT_DIRS))
+echo "    Keeping $KEPT_DIRS directories (excluded $EXCLUDED build tools)"
+
+# Show what was excluded
+if [[ "$EXCLUDED" -gt 0 ]]; then
+  echo "    Excluded:"
+  comm -23 <(sort "$INST_DIRS_FILE") <(sort "$FILTERED_FILE") | while read -r dir; do
+    echo "      - $(basename "$dir")"
+  done
+fi
+
+# ── Step 3: Copy into staging area ───────────────────────────────────────────
+
+echo "==> Staging artifacts..."
+
+STAGE=$(mktemp -d)
+trap 'rm -f "$INST_DIRS_FILE" "$FILTERED_FILE"; rm -rf "$STAGE"' EXIT
+
+while IFS= read -r dir; do
+  if [[ -d "$dir" ]]; then
+    cp -a "$dir/." "$STAGE/"
+  else
+    echo "    Warning: directory not found, skipping: $dir" >&2
+  fi
+done < "$FILTERED_FILE"
+
+# Save cmake_prefix_path for consumers
+tr '\n' ';' < "$FILTERED_FILE" > "$STAGE/cmake_prefix_path.txt"
+
+# Report pre-strip size
+PRE_STRIP_SIZE=$(du -sh "$STAGE" | cut -f1)
+echo "    Staged size (before strip): $PRE_STRIP_SIZE"
+
+# ── Step 4: Strip debug symbols ─────────────────────────────────────────────
+
+echo "==> Stripping debug symbols..."
+
+OS=$(uname -s)
+STRIPPED=0
+DEBUG_CREATED=0
+
+if [[ "$OS" == "Darwin" ]]; then
+  # macOS: strip -S removes debug symbols, keeps symbol table.
+  # No .debug sidecar generation (macOS uses dSYM bundles differently).
+  while IFS= read -r -d '' lib; do
+    strip -S "$lib" 2>/dev/null && STRIPPED=$((STRIPPED + 1)) || true
+  done < <(find "$STAGE" \( -name '*.a' -o -name '*.dylib' \) -type f -print0)
+  echo "    macOS: stripped $STRIPPED libraries (no .debug files generated)"
+
+elif [[ "$OS" == "Linux" ]]; then
+  # Linux: extract .debug sidecar files, then strip.
+  # .debug files go alongside the original in a .debug/ subdirectory,
+  # mirroring the original directory structure.
+  while IFS= read -r -d '' lib; do
+    LIBDIR=$(dirname "$lib")
+    LIBNAME=$(basename "$lib")
+    DEBUGDIR="$LIBDIR/.debug"
+
+    # Only process files that actually contain debug info
+    if ! objdump -h "$lib" 2>/dev/null | grep -q '\.debug_info'; then
+      continue
+    fi
+
+    mkdir -p "$DEBUGDIR"
+
+    # Extract debug info into sidecar file
+    if objcopy --only-keep-debug "$lib" "$DEBUGDIR/${LIBNAME}.debug" 2>/dev/null; then
+      DEBUG_CREATED=$((DEBUG_CREATED + 1))
+    fi
+
+    # Strip the original
+    if strip --strip-debug "$lib" 2>/dev/null; then
+      STRIPPED=$((STRIPPED + 1))
+
+      # Add debuglink so GDB can find the .debug file automatically
+      objcopy --add-gnu-debuglink="$DEBUGDIR/${LIBNAME}.debug" "$lib" 2>/dev/null || true
+    fi
+  done < <(find "$STAGE" \( -name '*.a' -o -name '*.so' -o -name '*.so.*' \) -type f -print0)
+  echo "    Linux: stripped $STRIPPED libraries, created $DEBUG_CREATED .debug files"
+
+else
+  echo "    Warning: unknown OS '$OS', skipping strip" >&2
+fi
+
+POST_STRIP_SIZE=$(du -sh "$STAGE" | cut -f1)
+echo "    Staged size (after strip): $POST_STRIP_SIZE"
+
+# ── Step 5: Create tarball ───────────────────────────────────────────────────
+
+echo "==> Creating tarball: $OUTPUT"
+
+# Ensure output directory exists
+mkdir -p "$(dirname "$OUTPUT")"
+
+tar czf "$OUTPUT" -C "$STAGE" .
+
+TARBALL_SIZE=$(du -sh "$OUTPUT" | cut -f1)
+echo "    Tarball size: $TARBALL_SIZE"
+
+# Check against GitHub Release 2GB limit
+TARBALL_BYTES=$(stat --format=%s "$OUTPUT" 2>/dev/null || stat -f%z "$OUTPUT" 2>/dev/null)
+LIMIT=$((2 * 1024 * 1024 * 1024))  # 2 GiB
+if [[ "$TARBALL_BYTES" -ge "$LIMIT" ]]; then
+  echo "WARNING: Tarball exceeds GitHub Release 2 GiB limit ($TARBALL_SIZE)!" >&2
+  echo "         Consider excluding more dependencies or verifying strip worked." >&2
+  exit 1
+fi
+
+echo "==> Done. Summary:"
+echo "    Install dirs: $TOTAL_DIRS total, $KEPT_DIRS kept, $EXCLUDED excluded"
+echo "    Size: $PRE_STRIP_SIZE -> $POST_STRIP_SIZE (staged) -> $TARBALL_SIZE (compressed)"

--- a/openmoq/scripts/create-release.sh
+++ b/openmoq/scripts/create-release.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# create-release.sh — Create a GitHub Release from artifact tarballs.
+#
+# Collects .tar.gz files from an artifacts directory, creates (or replaces)
+# a GitHub Release tagged build-<sha>, and prunes old build releases.
+#
+# Usage:
+#   create-release.sh \
+#     --artifacts-dir ./release-assets \
+#     --sha <full-commit-sha> \
+#     --keep 20
+#
+# Requires: gh CLI authenticated with a token that has contents:write.
+
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+
+ARTIFACTS_DIR=""
+SHA=""
+KEEP=20
+REPO=""  # defaults to current repo if empty
+DRY_RUN=false
+
+# ── Argument parsing ─────────────────────────────────────────────────────────
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --artifacts-dir DIR --sha SHA [OPTIONS]
+
+Options:
+  --artifacts-dir DIR   Directory containing .tar.gz artifact files
+  --sha SHA             Full commit SHA for the release tag
+  --keep N              Number of old build releases to keep (default: 20)
+  --repo OWNER/REPO     GitHub repository (default: current repo from gh)
+  --dry-run             Show what would be done without creating the release
+  -h, --help            Show this help
+EOF
+  exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --artifacts-dir) ARTIFACTS_DIR="$2"; shift 2 ;;
+    --sha)           SHA="$2"; shift 2 ;;
+    --keep)          KEEP="$2"; shift 2 ;;
+    --repo)          REPO="$2"; shift 2 ;;
+    --dry-run)       DRY_RUN=true; shift ;;
+    -h|--help)       usage 0 ;;
+    *)               echo "Unknown option: $1" >&2; usage 1 ;;
+  esac
+done
+
+if [[ -z "$ARTIFACTS_DIR" || -z "$SHA" ]]; then
+  echo "Error: --artifacts-dir and --sha are required." >&2
+  usage 1
+fi
+
+if [[ ! -d "$ARTIFACTS_DIR" ]]; then
+  echo "Error: artifacts directory does not exist: $ARTIFACTS_DIR" >&2
+  exit 1
+fi
+
+REPO_FLAG=""
+if [[ -n "$REPO" ]]; then
+  REPO_FLAG="--repo $REPO"
+fi
+
+# ── Step 1: Collect artifact files ───────────────────────────────────────────
+
+echo "==> Collecting artifacts from: $ARTIFACTS_DIR"
+
+# download-artifact@v4 creates a subdirectory per artifact name.
+# Flatten: find all .tar.gz files regardless of nesting depth.
+RELEASE_DIR=$(mktemp -d)
+trap 'rm -rf "$RELEASE_DIR"' EXIT
+
+ASSET_COUNT=0
+while IFS= read -r -d '' tarball; do
+  cp "$tarball" "$RELEASE_DIR/"
+  ASSET_COUNT=$((ASSET_COUNT + 1))
+  SIZE=$(du -sh "$tarball" | cut -f1)
+  echo "    $(basename "$tarball"): $SIZE"
+done < <(find "$ARTIFACTS_DIR" -name '*.tar.gz' -type f -print0)
+
+if [[ "$ASSET_COUNT" -eq 0 ]]; then
+  echo "Error: no .tar.gz files found in $ARTIFACTS_DIR" >&2
+  exit 1
+fi
+
+echo "    Found $ASSET_COUNT artifact(s)"
+
+# ── Step 2: Create release ───────────────────────────────────────────────────
+
+SHORT_SHA="${SHA:0:12}"
+TAG="build-${SHORT_SHA}"
+
+echo "==> Creating release: $TAG"
+
+if [[ "$DRY_RUN" == true ]]; then
+  echo "    [dry-run] Would delete existing release $TAG"
+  echo "    [dry-run] Would create release $TAG with $ASSET_COUNT assets"
+else
+  # Delete existing release with this tag if it exists (idempotent)
+  # shellcheck disable=SC2086
+  gh release delete "$TAG" --yes $REPO_FLAG 2>/dev/null || true
+  git tag -d "$TAG" 2>/dev/null || true
+  git push origin ":refs/tags/$TAG" 2>/dev/null || true
+
+  # Create the release
+  # shellcheck disable=SC2086
+  gh release create "$TAG" \
+    --title "Build artifacts for ${SHORT_SHA}" \
+    --notes "$(cat <<EOF
+Automated build artifacts for commit \`${SHORT_SHA}\`.
+
+These bundles contain moxygen and all transitive Meta dependencies
+(folly, fizz, wangle, mvfst, proxygen) as static libraries with
+headers and CMake config files. Debug symbols are in \`.debug/\`
+sidecar files (Linux only).
+
+**Usage in o-rly CI:**
+\`\`\`bash
+gh release download "${TAG}" --repo openmoq/moxygen \\
+  --pattern "moxygen-<platform>.tar.gz" --dir .scratch/
+tar xzf .scratch/moxygen-*.tar.gz -C .scratch/
+\`\`\`
+EOF
+    )" \
+    $REPO_FLAG \
+    "$RELEASE_DIR"/*.tar.gz
+
+  echo "    Release created: $TAG"
+fi
+
+# ── Step 3: Prune old releases ───────────────────────────────────────────────
+
+echo "==> Pruning old build releases (keeping last $KEEP)..."
+
+# shellcheck disable=SC2086
+OLD_RELEASES=$(gh release list --limit 100 $REPO_FLAG \
+  | grep '^build-' \
+  | tail -n +$((KEEP + 1)) \
+  | awk '{print $1}') || true
+
+if [[ -z "$OLD_RELEASES" ]]; then
+  echo "    Nothing to prune"
+else
+  echo "$OLD_RELEASES" | while read -r tag; do
+    if [[ "$DRY_RUN" == true ]]; then
+      echo "    [dry-run] Would delete: $tag"
+    else
+      echo "    Deleting: $tag"
+      # shellcheck disable=SC2086
+      gh release delete "$tag" --yes --cleanup-tag $REPO_FLAG
+    fi
+  done
+fi
+
+echo "==> Done."


### PR DESCRIPTION
## Summary

- **Fix >2GB tarball**: Exclude 6 build-tool deps (ninja, cmake, autoconf, automake, libtool, gperf) from artifact tarballs, strip debug symbols with `.debug` sidecar files
- **Fix bookworm artifact upload**: Write tarball to `$GITHUB_WORKSPACE/` instead of `runner.temp` for container path compatibility
- **Extract workflow logic into locally-testable scripts**: `openmoq/scripts/collect-artifacts.sh` and `openmoq/scripts/create-release.sh`
- Remove retired libaio patch (fix now upstream)
- Add fork marker file

## Test plan

- [x] `collect-artifacts.sh` tested locally with mock getdeps scratch dir — filtering, stripping, `.debug` sidecars all verified
- [x] `create-release.sh` tested locally with `--dry-run` — handles download-artifact subdirectory structure correctly
- [x] Exclude pattern validated against real `getdeps.py show-inst-dir` output (hash-suffixed dir names)
- [ ] Full CI validation on merge to main (publish-artifacts workflow)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/16)
<!-- Reviewable:end -->
