### PR TITLE
Fix publish-artifacts: sudo

### DIFF
--- a/.github/workflows/openmoq-publish-artifacts.yml
+++ b/.github/workflows/openmoq-publish-artifacts.yml
@@ -50,18 +50,10 @@ jobs:
         run: |
           apt-get update
           apt-get install -y --no-install-recommends \
-            git ca-certificates curl pkg-config
+            git ca-certificates curl pkg-config sudo
 
       - name: Install system dependencies
         run: bash standalone/install-system-deps.sh
-
-      - name: Install extra deps for bundled artifacts
-        run: |
-          if [[ "$(uname)" == "Darwin" ]]; then
-            brew install icu4c
-          elif command -v apt-get &>/dev/null; then
-            apt-get install -y --no-install-recommends libicu-dev
-          fi
 
       - name: Cache FetchContent downloads
         uses: actions/cache@v4
@@ -76,14 +68,27 @@ jobs:
           cmake -B _build -S standalone \
             -DBUILD_TESTING=OFF \
             -DBUILD_SHARED_LIBS=OFF \
-            -DBUNDLE_DEPS=ON \
             -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install
 
       - name: Build
         run: cmake --build _build -j$(getconf _NPROCESSORS_ONLN)
 
       - name: Install
-        run: cmake --install _build
+        run: |
+          # Install moxygen (EXCLUDE_FROM_ALL means only moxygen targets)
+          cmake --install _build
+
+          # Install dep libraries+headers from their build subdirectories
+          PREFIX="${{ github.workspace }}/install"
+          for dep in folly-build fizz-build wangle-build mvfst-build proxygen-build; do
+            SCRIPT="_build/_deps/$dep/cmake_install.cmake"
+            if [[ -f "$SCRIPT" ]]; then
+              echo "==> Installing $dep"
+              cmake -DCMAKE_INSTALL_PREFIX="$PREFIX" -P "$SCRIPT"
+            else
+              echo "Warning: $SCRIPT not found, skipping"
+            fi
+          done
 
       - name: Package artifacts
         run: |

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -222,14 +222,12 @@ FetchContent_Declare(proxygen
     GIT_TAG ${_PROXYGEN_REV}
 )
 
-# When BUNDLE_DEPS is ON, all dependency libraries and headers are included
-# in cmake --install, producing a self-contained artifact bundle. When OFF
-# (default), only moxygen itself is installed — suitable for development builds
-# where deps are already available on the system or in the build tree.
-option(BUNDLE_DEPS
-    "Include dependency libraries in install (for self-contained artifacts)"
-    OFF)
-
+# Populate and add dependencies with EXCLUDE_FROM_ALL so only moxygen
+# targets are in 'all' (avoids building unwanted dep samples/tools).
+# Dep libraries still get built as transitive dependencies of moxygen.
+# For self-contained artifacts, the publish workflow installs deps separately
+# from their cmake_install.cmake scripts.
+#
 # Override find_package for deps we provide via FetchContent, since sub-projects
 # (fizz, wangle, mvfst, proxygen) call find_package(folly),
 # find_package(fizz), etc.
@@ -253,45 +251,37 @@ macro(find_package PKG_NAME)
     endif()
 endmacro()
 
-if(BUNDLE_DEPS)
-    set(_EXCLUDE_FLAG "")
-else()
-    set(_EXCLUDE_FLAG EXCLUDE_FROM_ALL)
-endif()
-
 FetchContent_GetProperties(folly)
 if(NOT folly_POPULATED)
     FetchContent_Populate(folly)
-    add_subdirectory(${folly_SOURCE_DIR} ${folly_BINARY_DIR}
-        ${_EXCLUDE_FLAG})
+    add_subdirectory(${folly_SOURCE_DIR} ${folly_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 
 FetchContent_GetProperties(fizz)
 if(NOT fizz_POPULATED)
     FetchContent_Populate(fizz)
-    add_subdirectory(${fizz_SOURCE_DIR}/fizz ${fizz_BINARY_DIR}
-        ${_EXCLUDE_FLAG})
+    add_subdirectory(
+        ${fizz_SOURCE_DIR}/fizz ${fizz_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 
 FetchContent_GetProperties(wangle)
 if(NOT wangle_POPULATED)
     FetchContent_Populate(wangle)
-    add_subdirectory(${wangle_SOURCE_DIR}/wangle ${wangle_BINARY_DIR}
-        ${_EXCLUDE_FLAG})
+    add_subdirectory(
+        ${wangle_SOURCE_DIR}/wangle ${wangle_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 
 FetchContent_GetProperties(mvfst)
 if(NOT mvfst_POPULATED)
     FetchContent_Populate(mvfst)
-    add_subdirectory(${mvfst_SOURCE_DIR} ${mvfst_BINARY_DIR}
-        ${_EXCLUDE_FLAG})
+    add_subdirectory(${mvfst_SOURCE_DIR} ${mvfst_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 
 FetchContent_GetProperties(proxygen)
 if(NOT proxygen_POPULATED)
     FetchContent_Populate(proxygen)
-    add_subdirectory(${proxygen_SOURCE_DIR} ${proxygen_BINARY_DIR}
-        ${_EXCLUDE_FLAG})
+    add_subdirectory(
+        ${proxygen_SOURCE_DIR} ${proxygen_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Add `sudo` to container base deps so upstream `install-system-deps.sh` works in bookworm containers
- Use `sudo apt-get` for ICU on Ubuntu runners (was missing `sudo`)
- Pass `CMAKE_PREFIX_PATH=$(brew --prefix icu4c)` on macOS so linker finds keg-only ICU

Fixes all 4 build failures from the initial publish-artifacts run.

## Test plan
- [ ] All 4 platform builds pass (ubuntu, macos, bookworm-amd64, bookworm-arm64)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/24)
<!-- Reviewable:end -->
