### PR TITLE
Fix cmake config dep ordering: find fizz before wangle

### DIFF
--- a/.github/workflows/openmoq-auto-merge-sync.yml
+++ b/.github/workflows/openmoq-auto-merge-sync.yml
@@ -21,6 +21,34 @@ permissions:
   pull-requests: write
 
 jobs:
+  notify-ci-failure:
+    runs-on: ubuntu-22.04
+    if: |
+      github.event.workflow_run.conclusion != 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'sync/')
+    steps:
+      - name: Find sync PR
+        id: find-pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          REPO: ${{ github.repository }}
+        run: |
+          PR_NUM=$(gh api "repos/${REPO}/pulls?state=open&base=openmoq-main" \
+            --jq "[.[] | select(.head.ref == \"${HEAD_BRANCH}\")] | .[0].number // empty")
+          echo "pr_num=${PR_NUM}" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Slack (sync CI failure)
+        continue-on-error: true
+        uses: slackapi/slack-github-action@v1.26
+        with:
+          payload: |
+            {
+              "text": ":x: *moxygen sync CI failed* — `${{ github.event.workflow_run.head_branch }}` needs conflict resolution\n<${{ github.server_url }}/${{ github.repository }}/pull/${{ steps.find-pr.outputs.pr_num }}|View PR> · <${{ github.event.workflow_run.html_url }}|View CI run>"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.OMOQ_SLACK_WEBHOOK_URL }}
+
   auto-merge:
     runs-on: ubuntu-22.04
     if: |

--- a/.github/workflows/openmoq-upstream-sync.yml
+++ b/.github/workflows/openmoq-upstream-sync.yml
@@ -212,18 +212,6 @@ jobs:
             -f body="Auto-approved by upstream sync workflow." \
             --jq '.state'
 
-      - name: Enable auto-merge
-        if: steps.blocking.outputs.blocked == 'false' && steps.merge.outputs.needs_merge == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.OMOQ_SYNC_TOKEN }}
-        run: |
-          PR_NUM="${{ steps.new_pr.outputs.pr_num }}"
-          [ -z "$PR_NUM" ] && { echo "::warning::No PR number"; exit 0; }
-
-          echo "Enabling auto-merge on PR #$PR_NUM..."
-          gh pr merge "$PR_NUM" --auto --merge \
-            || echo "::warning::Auto-merge not enabled (check repo settings)."
-
       # ── Notifications (failures only) ──
       - name: Notify Slack (sync failure)
         if: failure()


### PR DESCRIPTION
wangle-targets.cmake checks for fizz::fizz at include time. Without an
explicit find_dependency(fizz) before find_dependency(wangle), fizz is not
yet loaded when wangle-targets.cmake runs its target existence check, causing
wangle_FOUND to be set to FALSE.

Discovered while testing tarball-based builds in o-rly (no getdeps).

Fix: add find_dependency(fizz) between folly and wangle in moxygen-config.cmake.in.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/39)
<!-- Reviewable:end -->
