### PR TITLE
Interim: add find_dependency(fizz) to cmake config

### DIFF
--- a/cmake/moxygen-config.cmake.in
+++ b/cmake/moxygen-config.cmake.in
@@ -13,6 +13,7 @@
 
 include(CMakeFindDependencyMacro)
 find_dependency(folly)
+find_dependency(fizz)
 find_dependency(wangle)
 find_dependency(mvfst)
 find_dependency(proxygen)


### PR DESCRIPTION
Interim fix: adds `find_dependency(fizz)` to `cmake/moxygen-config.cmake.in` so consumers using CMake find_package(moxygen) don't get a missing fizz dependency error.

Upstream fix submitted as facebookexperimental/moxygen#109. This branch will be retired once that merges and flows back through sync.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/42)
<!-- Reviewable:end -->
