### PR TITLE
publish: rename ubuntu artifact x86_64 → amd64

### DIFF
--- a/.github/workflows/openmoq-publish-artifacts.yml
+++ b/.github/workflows/openmoq-publish-artifacts.yml
@@ -20,8 +20,8 @@ jobs:
         include:
           - name: ubuntu-22.04-amd64
             runner: ubuntu-22.04
-            artifact: moxygen-ubuntu-22.04-x86_64.tar.gz
-            debug_artifact: moxygen-ubuntu-22.04-x86_64-dbg.tar.gz
+            artifact: moxygen-ubuntu-22.04-amd64.tar.gz
+            debug_artifact: moxygen-ubuntu-22.04-amd64-dbg.tar.gz
             container: ""
 
           - name: macos-15-arm64


### PR DESCRIPTION
Aligns ubuntu artifact filename with job name (`ubuntu-22.04-amd64`) and other platforms (bookworm uses `amd64`, macOS uses `arm64`).

Coordinate: o-rly `setup-deps-tarball.sh` updated in a companion PR to use `darch` for ubuntu (same conversion already applied to debian).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/50)
<!-- Reviewable:end -->
