### PR TITLE
Workflow renames, compact notifications, CI failure webhook

### DIFF
--- a/.github/workflows/openmoq-ci.yml
+++ b/.github/workflows/openmoq-ci.yml
@@ -1,4 +1,4 @@
-name: cmake
+name: build
 
 # Standalone build validation for PRs. Required status check for branch protection.
 

--- a/.github/workflows/openmoq-publish-artifacts.yml
+++ b/.github/workflows/openmoq-publish-artifacts.yml
@@ -1,4 +1,4 @@
-name: release publish
+name: publish release
 
 # Builds moxygen via standalone CMake on each target platform and publishes
 # per-architecture artifact bundles as a GitHub Release keyed by commit SHA.


### PR DESCRIPTION
Cleans up the check names in PRs from `pull request ci / linux (pull_request)` to `cmake / linux`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/52)
<!-- Reviewable:end -->
