### PR TITLE
Slack: bold repo, code-formatted branch/hash

### DIFF
--- a/.github/workflows/omoq-auto-merge-sync.yml
+++ b/.github/workflows/omoq-auto-merge-sync.yml
@@ -46,9 +46,8 @@ jobs:
         run: |
           PR_NUM="${{ steps.find-pr.outputs.pr_num }}"
           PR_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUM}"
-          CI_RUN_URL="${{ github.event.workflow_run.html_url }}"
           BRANCH="${{ github.event.workflow_run.head_branch }}"
-          TEXT=":x: *${{ github.repository }}* \`${BRANCH}\` verification failed — PR: <${PR_URL}|#${PR_NUM}> run: <${CI_RUN_URL}|view>"
+          TEXT=":x: *${{ github.repository }}* \`${BRANCH}\` — verification failed: PR: <${PR_URL}|#${PR_NUM}>"
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             --data "{\"text\": \"${TEXT}\"}"

--- a/.github/workflows/omoq-auto-merge-sync.yml
+++ b/.github/workflows/omoq-auto-merge-sync.yml
@@ -1,13 +1,13 @@
 name: sync auto-merge
 
 # Fires when verify completes on a sync/* branch.
-# If CI passed, merges the corresponding open sync PR into main.
-# If CI failed, sends Slack + email notifications.
+# If build passed, merges the corresponding open sync PR into main.
+# If build failed, sends Slack + email notifications.
 #
 # Single job with step-level conditions avoids "Skipped" job noise.
 #
 # NOTE: This workflow runs from the default branch (workflow_run events always
-# use the default branch). The sync PR must already be approved before CI runs.
+# use the default branch). The sync PR must already be approved before verify runs.
 
 on:
   workflow_run:
@@ -36,9 +36,9 @@ jobs:
             --jq "[.[] | select(.head.ref == \"${HEAD_BRANCH}\")] | .[0].number // empty")
           echo "pr_num=${PR_NUM}" >> "$GITHUB_OUTPUT"
 
-      # ── CI failed: notify ──────────────────────────────────────────────
+      # ── build failed: notify ──────────────────────────────────────────
 
-      - name: Notify Slack (CI failure)
+      - name: Notify Slack (build failure)
         if: github.event.workflow_run.conclusion != 'success'
         continue-on-error: true
         env:
@@ -48,12 +48,12 @@ jobs:
           PR_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUM}"
           CI_RUN_URL="${{ github.event.workflow_run.html_url }}"
           BRANCH="${{ github.event.workflow_run.head_branch }}"
-          TEXT=":x: *${{ github.repository }}* \`${BRANCH}\` CI failed — PR: <${PR_URL}|#${PR_NUM}> run: <${CI_RUN_URL}|view>"
+          TEXT=":x: *${{ github.repository }}* \`${BRANCH}\` build failed — PR: <${PR_URL}|#${PR_NUM}> run: <${CI_RUN_URL}|view>"
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             --data "{\"text\": \"${TEXT}\"}"
 
-      - name: Notify email (CI failure)
+      - name: Notify email (build failure)
         if: github.event.workflow_run.conclusion != 'success'
         continue-on-error: true
         env:
@@ -65,8 +65,8 @@ jobs:
           BRANCH="${{ github.event.workflow_run.head_branch }}"
           PR_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUM}"
           CI_RUN_URL="${{ github.event.workflow_run.html_url }}"
-          SUBJECT="[moxygen] sync CI failed — ${BRANCH}"
-          BODY="Sync branch CI failed — needs conflict resolution.\n\nBranch: ${BRANCH}\nPR: ${PR_URL}\nCI Run: ${CI_RUN_URL}"
+          SUBJECT="[moxygen] sync build failed — ${BRANCH}"
+          BODY="Sync branch build failed — needs conflict resolution.\n\nBranch: ${BRANCH}\nPR: ${PR_URL}\nRun: ${CI_RUN_URL}"
           aws ses send-email \
             --from "noreply@ci.openmoq.org" \
             --destination '{"ToAddresses":["github-notifications@openmoq.org"]}' \
@@ -75,7 +75,7 @@ jobs:
               \"Body\": {\"Text\": {\"Data\": \"${BODY}\"}}
             }"
 
-      # ── CI passed: merge ───────────────────────────────────────────────
+      # ── build passed: merge ──────────────────────────────────────────────
 
       - name: Generate app token
         if: github.event.workflow_run.conclusion == 'success'
@@ -93,7 +93,7 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           REPO: ${{ github.repository }}
         run: |
-          echo "CI passed on ${HEAD_BRANCH} (${HEAD_SHA})"
+          echo "Build passed on ${HEAD_BRANCH} (${HEAD_SHA})"
 
           PR_NUM=$(gh api \
             "repos/${REPO}/pulls?state=open&base=main" \

--- a/.github/workflows/omoq-auto-merge-sync.yml
+++ b/.github/workflows/omoq-auto-merge-sync.yml
@@ -36,9 +36,9 @@ jobs:
             --jq "[.[] | select(.head.ref == \"${HEAD_BRANCH}\")] | .[0].number // empty")
           echo "pr_num=${PR_NUM}" >> "$GITHUB_OUTPUT"
 
-      # ── build failed: notify ──────────────────────────────────────────
+      # ── verification failed: notify ───────────────────────────────────
 
-      - name: Notify Slack (build failure)
+      - name: Notify Slack (verification failure)
         if: github.event.workflow_run.conclusion != 'success'
         continue-on-error: true
         env:
@@ -48,12 +48,12 @@ jobs:
           PR_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUM}"
           CI_RUN_URL="${{ github.event.workflow_run.html_url }}"
           BRANCH="${{ github.event.workflow_run.head_branch }}"
-          TEXT=":x: *${{ github.repository }}* \`${BRANCH}\` build failed — PR: <${PR_URL}|#${PR_NUM}> run: <${CI_RUN_URL}|view>"
+          TEXT=":x: *${{ github.repository }}* \`${BRANCH}\` verification failed — PR: <${PR_URL}|#${PR_NUM}> run: <${CI_RUN_URL}|view>"
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             --data "{\"text\": \"${TEXT}\"}"
 
-      - name: Notify email (build failure)
+      - name: Notify email (verification failure)
         if: github.event.workflow_run.conclusion != 'success'
         continue-on-error: true
         env:
@@ -65,8 +65,8 @@ jobs:
           BRANCH="${{ github.event.workflow_run.head_branch }}"
           PR_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUM}"
           CI_RUN_URL="${{ github.event.workflow_run.html_url }}"
-          SUBJECT="[moxygen] sync build failed — ${BRANCH}"
-          BODY="Sync branch build failed — needs conflict resolution.\n\nBranch: ${BRANCH}\nPR: ${PR_URL}\nRun: ${CI_RUN_URL}"
+          SUBJECT="[moxygen] sync verification failed — ${BRANCH}"
+          BODY="Sync branch verification failed — needs conflict resolution.\n\nBranch: ${BRANCH}\nPR: ${PR_URL}\nRun: ${CI_RUN_URL}"
           aws ses send-email \
             --from "noreply@ci.openmoq.org" \
             --destination '{"ToAddresses":["github-notifications@openmoq.org"]}' \

--- a/.github/workflows/omoq-auto-merge-sync.yml
+++ b/.github/workflows/omoq-auto-merge-sync.yml
@@ -48,7 +48,7 @@ jobs:
           PR_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUM}"
           CI_RUN_URL="${{ github.event.workflow_run.html_url }}"
           BRANCH="${{ github.event.workflow_run.head_branch }}"
-          TEXT=":x: moxygen ${BRANCH} CI failed — PR: <${PR_URL}|#${PR_NUM}> run: <${CI_RUN_URL}|view>"
+          TEXT=":x: *${{ github.repository }}* \`${BRANCH}\` CI failed — PR: <${PR_URL}|#${PR_NUM}> run: <${CI_RUN_URL}|view>"
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             --data "{\"text\": \"${TEXT}\"}"

--- a/.github/workflows/omoq-publish-artifacts.yml
+++ b/.github/workflows/omoq-publish-artifacts.yml
@@ -144,9 +144,9 @@ jobs:
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           if [ "${{ needs.build.result }}" = "success" ]; then
             REL_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/snapshot-latest"
-            TEXT=":white_check_mark: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — run: <${RUN_URL}|#${{ github.run_number }}> artifacts: <${REL_URL}|view>"
+            TEXT=":white_check_mark: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — publish release: <${RUN_URL}|#${{ github.run_number }}> artifacts: <${REL_URL}|view>"
           else
-            TEXT=":x: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — run: <${RUN_URL}|#${{ github.run_number }}>"
+            TEXT=":x: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — publish release: <${RUN_URL}|#${{ github.run_number }}>"
           fi
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \

--- a/.github/workflows/omoq-publish-artifacts.yml
+++ b/.github/workflows/omoq-publish-artifacts.yml
@@ -146,7 +146,7 @@ jobs:
             REL_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/snapshot-latest"
             TEXT=":white_check_mark: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — publish release: <${RUN_URL}|#${{ github.run_number }}> artifacts: <${REL_URL}|view>"
           else
-            TEXT=":x: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — publish release: <${RUN_URL}|#${{ github.run_number }}>"
+            TEXT=":x: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — publish release failed: <${RUN_URL}|#${{ github.run_number }}>"
           fi
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \

--- a/.github/workflows/omoq-publish-artifacts.yml
+++ b/.github/workflows/omoq-publish-artifacts.yml
@@ -144,9 +144,9 @@ jobs:
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           if [ "${{ needs.build.result }}" = "success" ]; then
             REL_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/snapshot-latest"
-            TEXT=":white_check_mark: moxygen ${{ github.ref_name }} ${SHORT} — run: <${RUN_URL}|#${{ github.run_number }}> artifacts: <${REL_URL}|view>"
+            TEXT=":white_check_mark: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — run: <${RUN_URL}|#${{ github.run_number }}> artifacts: <${REL_URL}|view>"
           else
-            TEXT=":x: moxygen ${{ github.ref_name }} ${SHORT} — run: <${RUN_URL}|#${{ github.run_number }}>"
+            TEXT=":x: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — run: <${RUN_URL}|#${{ github.run_number }}>"
           fi
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \

--- a/.github/workflows/omoq-upstream-sync.yml
+++ b/.github/workflows/omoq-upstream-sync.yml
@@ -62,9 +62,10 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.OMOQ_SLACK_WEBHOOK_URL }}
         run: |
+          SHORT="${GITHUB_SHA:0:7}"
           PR_NUM="${{ steps.blocking.outputs.pr_num }}"
           PR_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUM}"
-          TEXT=":pause_button: *${{ github.repository }}* upstream sync paused — PR <${PR_URL}|#${PR_NUM}> pending"
+          TEXT=":pause_button: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — upstream sync paused: PR <${PR_URL}|#${PR_NUM}> pending"
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             --data "{\"text\": \"${TEXT}\"}"
@@ -242,8 +243,9 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.OMOQ_SLACK_WEBHOOK_URL }}
         run: |
+          SHORT="${GITHUB_SHA:0:7}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          TEXT=":warning: *${{ github.repository }}* upstream sync failed — run: <${RUN_URL}|#${{ github.run_number }}>"
+          TEXT=":warning: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — upstream sync failed: Run <${RUN_URL}|#${{ github.run_number }}>"
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             --data "{\"text\": \"${TEXT}\"}"

--- a/.github/workflows/omoq-upstream-sync.yml
+++ b/.github/workflows/omoq-upstream-sync.yml
@@ -120,7 +120,7 @@ jobs:
               break
             fi
 
-            # Check CI status
+            # Check build status
             STATE=$(gh api "repos/facebookexperimental/moxygen/commits/$SHA/check-suites" \
               -q '[.check_suites[] | select(.app.name=="GitHub Actions")] |
                   if length == 0 then "failure"
@@ -207,7 +207,7 @@ jobs:
           - **Upstream status:** success (green)
           - **Merge type:** git merge (sync/$SYNC_SHA → main)
 
-          CI will validate the standalone build. On success, this PR auto-merges.
+          The verify workflow will validate the standalone build. On success, this PR auto-merges.
           Devs can push conflict-resolution commits to \`$BRANCH\` if needed.
 
           Created by \`omoq-upstream-sync\` workflow.

--- a/.github/workflows/omoq-upstream-sync.yml
+++ b/.github/workflows/omoq-upstream-sync.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           PR_NUM="${{ steps.blocking.outputs.pr_num }}"
           PR_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUM}"
-          TEXT=":pause_button: *${{ github.repository }}* sync paused — PR <${PR_URL}|#${PR_NUM}> pending"
+          TEXT=":pause_button: *${{ github.repository }}* upstream sync paused — PR <${PR_URL}|#${PR_NUM}> pending"
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             --data "{\"text\": \"${TEXT}\"}"

--- a/.github/workflows/omoq-upstream-sync.yml
+++ b/.github/workflows/omoq-upstream-sync.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           PR_NUM="${{ steps.blocking.outputs.pr_num }}"
           PR_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUM}"
-          TEXT=":pause_button: moxygen sync paused — PR <${PR_URL}|#${PR_NUM}> pending"
+          TEXT=":pause_button: *${{ github.repository }}* sync paused — PR <${PR_URL}|#${PR_NUM}> pending"
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             --data "{\"text\": \"${TEXT}\"}"
@@ -243,7 +243,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.OMOQ_SLACK_WEBHOOK_URL }}
         run: |
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          TEXT=":warning: moxygen upstream sync failed — run: <${RUN_URL}|#${{ github.run_number }}>"
+          TEXT=":warning: *${{ github.repository }}* upstream sync failed — run: <${RUN_URL}|#${{ github.run_number }}>"
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             --data "{\"text\": \"${TEXT}\"}"


### PR DESCRIPTION
Cosmetic fix for Slack notification formatting.

- Bold `*org/repo*` instead of plain text
- Backtick-wrap branch name and commit hash for amber monospace rendering
- Matches the existing o-rly Slack notification style

Affects: `omoq-publish-artifacts.yml`, `omoq-auto-merge-sync.yml`, `omoq-upstream-sync.yml`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/57)
<!-- Reviewable:end -->
