### PR TITLE
Prefer static system libraries in artifact builds

### DIFF
--- a/.github/workflows/omoq-upstream-sync.yml
+++ b/.github/workflows/omoq-upstream-sync.yml
@@ -199,6 +199,22 @@ jobs:
           git push origin "origin/upstream:refs/heads/$BRANCH"
           echo "Created branch $BRANCH"
 
+          # Pre-merge main into sync branch to resolve expected conflicts
+          # (github_hashes files diverge every sync; upstream version wins)
+          git fetch origin "$BRANCH"
+          git checkout -B "$BRANCH" "origin/$BRANCH"
+          if ! git merge origin/main -X ours --no-edit; then
+            echo "::error::Merge conflicts could not be auto-resolved."
+            echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
+            git merge --abort
+            git checkout main
+          else
+            echo "Pre-merged main into sync branch (conflicts auto-resolved)"
+            git push origin "$BRANCH"
+            echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
+            git checkout main
+          fi
+
           PR_NUM=$(gh api repos/${{ github.repository }}/pulls \
             -f title="sync: upstream moxygen $SYNC_SHA" \
             -f body="$(cat <<EOF
@@ -220,6 +236,44 @@ jobs:
 
           echo "Created sync PR #$PR_NUM"
           echo "pr_num=$PR_NUM" >> "$GITHUB_OUTPUT"
+
+      # ── Notify merge conflicts ──
+      - name: Notify conflicts (Slack)
+        if: steps.new_pr.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.OMOQ_SLACK_WEBHOOK_URL }}
+        run: |
+          PR_NUM="${{ steps.new_pr.outputs.pr_num }}"
+          PR_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUM}"
+          SYNC_SHA="${{ steps.merge.outputs.sync_sha }}"
+          TEXT=":warning: *${{ github.repository }}* sync \`${SYNC_SHA}\` has merge conflicts — PR <${PR_URL}|#${PR_NUM}> needs manual resolution"
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            --data "{\"text\": \"${TEXT}\"}"
+
+      - name: Notify conflicts (email)
+        if: steps.new_pr.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.OMOQ_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.OMOQ_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          PR_NUM="${{ steps.new_pr.outputs.pr_num }}"
+          PR_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUM}"
+          SYNC_SHA="${{ steps.merge.outputs.sync_sha }}"
+          FULL_SHA=$(git rev-parse origin/upstream)
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SUBJECT="[moxygen] sync ${SYNC_SHA} has merge conflicts"
+          BODY="Automated upstream sync created a PR with merge conflicts that could not be auto-resolved.\n\nPR: ${PR_URL}\nUpstream commit: ${FULL_SHA}\nRun: ${RUN_URL}\n\nManual conflict resolution required."
+          aws ses send-email \
+            --from "noreply@ci.openmoq.org" \
+            --destination '{"ToAddresses":["github-notifications@openmoq.org"]}' \
+            --message "{
+              \"Subject\": {\"Data\": \"${SUBJECT}\"},
+              \"Body\": {\"Text\": {\"Data\": \"${BODY}\"}}
+            }"
 
       # ── Approve and enable auto-merge ──
       - name: Approve PR

--- a/openmoq/scripts/publish-artifacts.sh
+++ b/openmoq/scripts/publish-artifacts.sh
@@ -152,6 +152,16 @@ EOF
     upload_with_retry "$asset"
   done
 
+  # Ensure the release is not stuck as draft
+  # (gh release create without files may leave it in draft state)
+  RELEASE_ID=$(gh api repos/{owner}/{repo}/releases \
+    --jq ".[] | select(.tag_name == \"$TAG\") | .id")
+  if [[ -n "$RELEASE_ID" ]]; then
+    gh api "repos/{owner}/{repo}/releases/$RELEASE_ID" \
+      -X PATCH -f draft=false >/dev/null
+    echo "    Release published (draft=false)"
+  fi
+
   echo "    Snapshot published: $TAG"
 fi
 

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -90,6 +90,17 @@ find_package(Threads REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(gflags CONFIG REQUIRED)
 find_package(Glog REQUIRED)
+# FindGlog.cmake internally calls find_package(LibUnwind), which with
+# CMAKE_FIND_LIBRARY_SUFFIXES=".a" picks up libunwind.a.  On Debian/Ubuntu
+# x86_64 that file is not compiled with -fPIC, causing PIE link failure.
+# Patch the glog target to use the shared library instead.
+if(BUNDLE_DEPS AND CMAKE_SYSTEM_NAME STREQUAL "Linux" AND TARGET glog::glog)
+    get_target_property(_glog_link_libs glog::glog IMPORTED_LINK_INTERFACE_LIBRARIES)
+    if(_glog_link_libs)
+        string(REGEX REPLACE "([/a-zA-Z0-9._-]*)libunwind\\.a" "\\1libunwind.so" _glog_link_libs "${_glog_link_libs}")
+        set_target_properties(glog::glog PROPERTIES IMPORTED_LINK_INTERFACE_LIBRARIES "${_glog_link_libs}")
+    endif()
+endif()
 find_package(fmt CONFIG REQUIRED)
 find_package(double-conversion CONFIG REQUIRED)
 find_package(Boost 1.70 REQUIRED COMPONENTS

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -28,6 +28,18 @@ option(BUILD_PICOQUIC "Build with picoquic transport support" OFF)
 # Linking preferences
 # =============================================================================
 
+# When building artifacts for distribution, prefer static system libraries
+# so the tarball consumers only need libc/libstdc++/libssl at runtime.
+if(BUNDLE_DEPS)
+    # MODULE-mode find_package() and find_library() respect this:
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+
+    # CONFIG-mode packages ignore CMAKE_FIND_LIBRARY_SUFFIXES and hardcode
+    # .so paths in their cmake configs. Use per-package variables instead:
+    set(GFLAGS_SHARED OFF CACHE BOOL "" FORCE)
+    set(Boost_USE_STATIC_LIBS ON)
+endif()
+
 find_package(ZLIB REQUIRED)
 find_library(ZSTD_LIBRARY NAMES zstd)
 
@@ -84,8 +96,13 @@ find_package(Zstd REQUIRED)
 find_package(LibEvent REQUIRED)
 find_package(Sodium REQUIRED)
 
-# Check for libunwind to decide if we need lzma for symbolization
+# Check for libunwind to decide if we need lzma for symbolization.
+# System libunwind.a on Ubuntu/Debian is not compiled with -fPIC, so it
+# can't link into PIE executables. Always find the shared library.
+set(_saved_find_suffixes "${CMAKE_FIND_LIBRARY_SUFFIXES}")
+set(CMAKE_FIND_LIBRARY_SUFFIXES ".so;.a")
 find_package(LibUnwind QUIET)
+set(CMAKE_FIND_LIBRARY_SUFFIXES "${_saved_find_suffixes}")
 
 # =============================================================================
 # FetchContent: Meta OSS Dependencies (using pinned hashes)

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -38,8 +38,13 @@ if(BUNDLE_DEPS)
     endif()
 
     # CONFIG-mode packages ignore CMAKE_FIND_LIBRARY_SUFFIXES and hardcode
-    # .so/.dylib paths in their cmake configs. Use per-package variables:
-    set(GFLAGS_SHARED OFF CACHE BOOL "" FORCE)
+    # .so/.dylib paths in their cmake configs. Use per-package variables.
+    # GFLAGS_SHARED OFF is Linux-only: on macOS, glog is always shared
+    # (homebrew has no libglog.a), and glog.dylib links gflags.dylib;
+    # mixing static gflags with shared glog causes dual-linkage crashes.
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        set(GFLAGS_SHARED OFF CACHE BOOL "" FORCE)
+    endif()
     set(Boost_USE_STATIC_LIBS ON)
 endif()
 

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -31,11 +31,14 @@ option(BUILD_PICOQUIC "Build with picoquic transport support" OFF)
 # When building artifacts for distribution, prefer static system libraries
 # so the tarball consumers only need libc/libstdc++/libssl at runtime.
 if(BUNDLE_DEPS)
-    # MODULE-mode find_package() and find_library() respect this:
-    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+    # MODULE-mode find_package() and find_library() respect this.
+    # Linux only: macOS/homebrew doesn't ship .a for zlib, fmt, etc.
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+    endif()
 
     # CONFIG-mode packages ignore CMAKE_FIND_LIBRARY_SUFFIXES and hardcode
-    # .so paths in their cmake configs. Use per-package variables instead:
+    # .so/.dylib paths in their cmake configs. Use per-package variables:
     set(GFLAGS_SHARED OFF CACHE BOOL "" FORCE)
     set(Boost_USE_STATIC_LIBS ON)
 endif()
@@ -97,12 +100,14 @@ find_package(LibEvent REQUIRED)
 find_package(Sodium REQUIRED)
 
 # Check for libunwind to decide if we need lzma for symbolization.
-# System libunwind.a on Ubuntu/Debian is not compiled with -fPIC, so it
-# can't link into PIE executables. Always find the shared library.
-set(_saved_find_suffixes "${CMAKE_FIND_LIBRARY_SUFFIXES}")
-set(CMAKE_FIND_LIBRARY_SUFFIXES ".so;.a")
-find_package(LibUnwind QUIET)
-set(CMAKE_FIND_LIBRARY_SUFFIXES "${_saved_find_suffixes}")
+# When BUNDLE_DEPS is on and CMAKE_FIND_LIBRARY_SUFFIXES=".a", folly's
+# internal find_library(LIBUNWIND) picks up libunwind.a which on
+# Ubuntu/Debian x86_64 is not compiled with -fPIC (PIE link failure).
+# Skip libunwind entirely for bundled builds — crash symbolizer is a
+# debug convenience, not needed in distributed artifacts.
+if(NOT BUNDLE_DEPS)
+    find_package(LibUnwind QUIET)
+endif()
 
 # =============================================================================
 # FetchContent: Meta OSS Dependencies (using pinned hashes)

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -100,12 +100,17 @@ find_package(LibEvent REQUIRED)
 find_package(Sodium REQUIRED)
 
 # Check for libunwind to decide if we need lzma for symbolization.
-# When BUNDLE_DEPS is on and CMAKE_FIND_LIBRARY_SUFFIXES=".a", folly's
-# internal find_library(LIBUNWIND) picks up libunwind.a which on
-# Ubuntu/Debian x86_64 is not compiled with -fPIC (PIE link failure).
-# Skip libunwind entirely for bundled builds — crash symbolizer is a
-# debug convenience, not needed in distributed artifacts.
-if(NOT BUNDLE_DEPS)
+# When BUNDLE_DEPS is on, CMAKE_FIND_LIBRARY_SUFFIXES=".a" would cause
+# folly to pick up libunwind.a which on Ubuntu/Debian x86_64 is not
+# compiled with -fPIC (PIE link failure). Find it here with .so preference
+# so the result is cached; folly's internal find_package(LibUnwind) is
+# then skipped via _FETCHCONTENT_PROVIDED_DEPS below.
+if(BUNDLE_DEPS AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(_saved_find_suffixes "${CMAKE_FIND_LIBRARY_SUFFIXES}")
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".so;.a")
+    find_package(LibUnwind QUIET)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES "${_saved_find_suffixes}")
+else()
     find_package(LibUnwind QUIET)
 endif()
 
@@ -260,6 +265,11 @@ set(_FETCHCONTENT_PROVIDED_DEPS folly fizz wangle mvfst proxygen GTest GMock
     BZip2 LZ4 Snappy glog Glog)
 if(BUILD_PICOQUIC)
     list(APPEND _FETCHCONTENT_PROVIDED_DEPS picoquic)
+endif()
+# When BUNDLE_DEPS is on, we already found libunwind with .so preference
+# above. Skip folly's internal re-find to prevent it picking up .a.
+if(BUNDLE_DEPS)
+    list(APPEND _FETCHCONTENT_PROVIDED_DEPS LibUnwind)
 endif()
 if(NOT LibUnwind_FOUND)
     list(APPEND _FETCHCONTENT_PROVIDED_DEPS LibLZMA)


### PR DESCRIPTION
## Summary

- Set `CMAKE_FIND_LIBRARY_SUFFIXES=".a"` when `BUNDLE_DEPS=ON` in the standalone build
- This makes folly's exported cmake config record `.a` paths instead of `.so` for system deps (double-conversion, libevent, libsodium, zstd, libunwind, etc.)
- Result: downstream binaries (o-rly) only need `libc`, `libstdc++`, and `libssl` at runtime

## Problem

The current tarball's cmake config has hardcoded `.so` paths like:
```
/usr/lib/x86_64-linux-gnu/libdouble-conversion.so
/usr/lib/x86_64-linux-gnu/libevent.so
/usr/lib/x86_64-linux-gnu/libsodium.so
...
```

This forces downstream binaries to dynamically link ~12 system libraries, making Docker images fragile (SONAME mismatches between build distro and runtime distro) and bloated.

## Test plan

- [x] CI passes on linux, macos, asan
- [ ] Verify ldd on the built binary shows only libc/libstdc++/libssl as dynamic deps
- [ ] Verify o-rly builds against the new tarball

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/58)
<!-- Reviewable:end -->
