### PR TITLE
Use Linode self-hosted runner for amd64 publish jobs

### DIFF
--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu-22.04
+          - runner: [self-hosted, linode]
             name: linux
             cache_prefix: ci-ninja-ubuntu-22.04
           - runner: macos-15
@@ -108,14 +108,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - runner: [self-hosted, linode]
             name: linux
             cache_prefix: ci-pico-ninja-ubuntu-22.04
-          - os: macos-15
+          - runner: macos-15
             name: macos
             cache_prefix: ci-pico-ninja-macos-15
     name: pico (${{ matrix.name }})
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
 
@@ -123,6 +123,7 @@ jobs:
         run: bash standalone/install-system-deps.sh
 
       - name: Cache FetchContent downloads
+        if: ${{ !contains(toJSON(matrix.runner), 'linode') }}
         uses: actions/cache@v4
         with:
           path: _build/_deps
@@ -131,6 +132,7 @@ jobs:
             ${{ matrix.cache_prefix }}-deps-
 
       - name: Set up ccache
+        if: ${{ !contains(toJSON(matrix.runner), 'linode') }}
         uses: hendrikmuhs/ccache-action@v1
         with:
           key: ${{ matrix.cache_prefix }}

--- a/.github/workflows/omoq-ci-pr.yml
+++ b/.github/workflows/omoq-ci-pr.yml
@@ -25,17 +25,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu-22.04
+          - os: ubuntu-22.04
             name: linux
             cache_prefix: ci-ninja-ubuntu-22.04
-          - runner: macos-15
+          - os: macos-15
             name: macos
             cache_prefix: ci-ninja-macos-15
-          - runner: [self-hosted, linode]
+          - os: ubuntu-22.04
             name: asan debug
             cache_prefix: ci-asan-ubuntu-22.04
     name: ${{ matrix.name }}
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -43,7 +43,6 @@ jobs:
         run: bash standalone/install-system-deps.sh
 
       - name: Cache FetchContent downloads
-        if: ${{ !contains(toJSON(matrix.runner), 'linode') }}
         uses: actions/cache@v4
         with:
           path: _build/_deps
@@ -52,7 +51,6 @@ jobs:
             ${{ matrix.cache_prefix }}-deps-
 
       - name: Set up ccache
-        if: ${{ !contains(toJSON(matrix.runner), 'linode') }}
         uses: hendrikmuhs/ccache-action@v1
         with:
           key: ${{ matrix.cache_prefix }}


### PR DESCRIPTION
## Summary
- Switch Linux amd64 publish jobs (ubuntu-22.04-amd64, bookworm-amd64) to Linode self-hosted runner for faster builds
- Skip GitHub Actions cache and ccache-action on self-hosted runners (deps persist on disk)
- Remove test-runner workflow and check-runner-deps script (served their purpose)
- Keep setup-runner.sh for future macOS runner setup

## Changes
- `omoq-ci-main.yml`: two publish matrix entries use `[self-hosted, linode]` runner
- `omoq-ci-main.yml`: conditional on cache steps to skip on self-hosted
- Deleted `omoq-test-runner.yml`, `standalone/check-runner-deps.sh`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/71)
<!-- Reviewable:end -->
