### PR TITLE
Pin picoquic getdeps manifest to afrind fork/branch

### DIFF
--- a/build/fbcode_builder/manifests/picoquic
+++ b/build/fbcode_builder/manifests/picoquic
@@ -2,8 +2,8 @@
 name = picoquic
 
 [git]
-repo_url = https://github.com/private-octopus/picoquic.git
-branch = master
+repo_url = https://github.com/afrind/picoquic.git
+branch = fix-picotls-brotli
 
 [build]
 builder = cmake


### PR DESCRIPTION
Match the repo and branch used by standalone/CMakeLists.txt (afrind/picoquic fix-picotls-brotli) so both build paths use the same picoquic source.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/73)
<!-- Reviewable:end -->
