### PR TITLE
Bundle fmt/sodium as static libs + add docker smoke test

### DIFF
--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -7,7 +7,7 @@ name: ci main
 #
 #   build (linux, macos, asan debug) ───────────────────────────────────────────┐
 #   build-pico (linux, macos) ──────────────────────────────────────────────────┤
-#   publish (4 platforms) ── docker-docker-smoke-test (bookworm) ──────────────────────┼── release ── notify
+#   publish (4 platforms) ── docker-smoke-test (bookworm) ──────────────────────┼── release ── notify
 
 on:
   push:
@@ -267,7 +267,7 @@ jobs:
   # Smoke test: verify bookworm tarball runs in a clean bookworm-slim container
   # ════════════════════════════════════════════════════════════════════════════
 
-  docker-docker-smoke-test:
+  docker-smoke-test:
     needs: [publish]
     name: docker smoke test (bookworm-amd64)
     runs-on: ubuntu-22.04

--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -5,8 +5,7 @@ name: ci main
 #
 # Job graph:
 #
-#   build (linux, macos, asan debug) ───────────────────────────────────────────┐
-#   build-pico (linux, macos) ──────────────────────────────────────────────────┤
+#   build (linux, macos, pico linux, pico macos, asan debug) ──────────────────┐
 #   publish (4 platforms) ─────────────────────────────────────────────────────┼── release ── notify
 
 on:
@@ -37,6 +36,14 @@ jobs:
           - os: macos-15
             name: macos
             cache_prefix: ci-ninja-macos-15
+          - os: ubuntu-22.04
+            name: pico (linux)
+            cache_prefix: ci-pico-ninja-ubuntu-22.04
+            picoquic: true
+          - os: macos-15
+            name: pico (macos)
+            cache_prefix: ci-pico-ninja-macos-15
+            picoquic: true
           - os: ubuntu-22.04
             name: asan debug
             cache_prefix: ci-asan-ubuntu-22.04
@@ -78,6 +85,7 @@ jobs:
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DBUILD_TESTING=ON \
+              ${{ matrix.picoquic && '-DBUILD_PICOQUIC=ON' || '' }} \
               -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/_install
           fi
 
@@ -99,65 +107,6 @@ jobs:
 
       - name: Install (smoke test)
         if: matrix.name != 'asan debug'
-        run: cmake --install _build
-
-  build-pico:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-22.04
-            name: linux
-            cache_prefix: ci-pico-ninja-ubuntu-22.04
-          - os: macos-15
-            name: macos
-            cache_prefix: ci-pico-ninja-macos-15
-    name: pico (${{ matrix.name }})
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install system dependencies
-        run: bash standalone/install-system-deps.sh
-
-      - name: Cache FetchContent downloads
-        uses: actions/cache@v4
-        with:
-          path: _build/_deps
-          key: ${{ matrix.cache_prefix }}-deps-${{ hashFiles('build/deps/github_hashes/**/*-rev.txt', 'standalone/patches/**') }}
-          restore-keys: |
-            ${{ matrix.cache_prefix }}-deps-
-
-      - name: Set up ccache
-        uses: hendrikmuhs/ccache-action@v1
-        with:
-          key: ${{ matrix.cache_prefix }}
-          max-size: 500M
-
-      - name: Configure
-        run: |
-          cmake -B _build -S standalone -G Ninja \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DBUILD_TESTING=ON \
-            -DBUILD_PICOQUIC=ON \
-            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/_install
-
-      - name: Build
-        run: cmake --build _build -j$(getconf _NPROCESSORS_ONLN)
-
-      - name: Test
-        run: ctest --test-dir _build --output-on-failure --output-junit test-results.xml
-
-      - name: Publish test results
-        uses: dorny/test-reporter@v1.9.1
-        if: success() || failure()
-        with:
-          name: "test pico (${{ matrix.name }})"
-          path: _build/test-results.xml
-          reporter: java-junit
-
-      - name: Install (smoke test)
         run: cmake --install _build
 
   # ════════════════════════════════════════════════════════════════════════════
@@ -268,7 +217,7 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
 
   release:
-    needs: [build, build-pico, publish]
+    needs: [build, publish]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -291,7 +240,7 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
 
   notify:
-    needs: [build, build-pico, publish, release]
+    needs: [build, publish, release]
     if: always()
     runs-on: ubuntu-22.04
     steps:
@@ -314,11 +263,10 @@ jobs:
           }
 
           VER=$(fmt_status "${{ needs.build.result }}")
-          PICO=$(fmt_status "${{ needs.build-pico.result }}")
           PUB=$(fmt_status "${{ needs.publish.result }}")
           REL=$(fmt_status "${{ needs.release.result }}")
 
-          STATUS="verify:${VER} pico:${PICO} publish:${PUB} release:${REL}"
+          STATUS="verify:${VER} publish:${PUB} release:${REL}"
 
           if [ "${{ needs.release.result }}" = "success" ]; then
             REL_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/snapshot-latest"
@@ -342,11 +290,10 @@ jobs:
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           VER="${{ needs.build.result }}"
-          PICO="${{ needs.build-pico.result }}"
           PUB="${{ needs.publish.result }}"
           REL="${{ needs.release.result }}"
 
-          STATUS="verify:${VER} pico:${PICO} publish:${PUB} release:${REL}"
+          STATUS="verify:${VER} publish:${PUB} release:${REL}"
 
           if [ "${{ needs.release.result }}" = "success" ]; then
             REL_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/snapshot-latest"

--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -5,9 +5,9 @@ name: ci main
 #
 # Job graph:
 #
-#   build (linux, macos, asan debug) ───────────────────┐
-#   build-pico (linux, macos) ──────────────────────────┼── release ── notify
-#   publish (4 platforms, needs: [build]) ──────────────┘  (snapshot)  (always)
+#   build (linux, macos, asan debug) ───────────────────────────────────────────┐
+#   build-pico (linux, macos) ──────────────────────────────────────────────────┤
+#   publish (4 platforms) ── docker-docker-smoke-test (bookworm) ──────────────────────┼── release ── notify
 
 on:
   push:
@@ -264,11 +264,52 @@ jobs:
           retention-days: 90
 
   # ════════════════════════════════════════════════════════════════════════════
+  # Smoke test: verify bookworm tarball runs in a clean bookworm-slim container
+  # ════════════════════════════════════════════════════════════════════════════
+
+  docker-docker-smoke-test:
+    needs: [publish]
+    name: docker smoke test (bookworm-amd64)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download bookworm artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: moxygen-bookworm-amd64.tar.gz
+          path: artifact/
+
+      - name: Extract tarball
+        run: |
+          mkdir -p install
+          tar xzf artifact/moxygen-bookworm-amd64.tar.gz -C install
+
+      - name: Smoke test in bookworm-slim
+        run: |
+          docker run --rm -v "$PWD/install:/mnt:ro" debian:bookworm-slim bash -c '
+            set -e
+            apt-get update -qq
+            apt-get install -y --no-install-recommends libunwind8 >/dev/null
+            echo "==> ldd /mnt/bin/moqrelayserver"
+            ldd /mnt/bin/moqrelayserver
+            if ldd /mnt/bin/moqrelayserver | grep -q "not found"; then
+              echo "ERROR: missing shared libraries"
+              exit 1
+            fi
+            echo "==> Running moqrelayserver --helpshort"
+            /mnt/bin/moqrelayserver --helpshort; RC=$?
+            if [ "$RC" -gt 1 ]; then
+              echo "ERROR: unexpected exit code $RC (crash or missing dep)"
+              exit 1
+            fi
+            echo "==> Smoke test passed"
+          '
+
+  # ════════════════════════════════════════════════════════════════════════════
   # Release: create/update snapshot-latest pre-release (main only, all green)
   # ════════════════════════════════════════════════════════════════════════════
 
   release:
-    needs: [build, build-pico, publish]
+    needs: [build, build-pico, publish, docker-smoke-test]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -291,7 +332,7 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
 
   notify:
-    needs: [build, build-pico, publish, release]
+    needs: [build, build-pico, publish, docker-smoke-test, release]
     if: always()
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -7,7 +7,7 @@ name: ci main
 #
 #   build (linux, macos, asan debug) ───────────────────────────────────────────┐
 #   build-pico (linux, macos) ──────────────────────────────────────────────────┤
-#   publish (4 platforms) ── docker-smoke-test (bookworm) ──────────────────────┼── release ── notify
+#   publish (4 platforms) ─────────────────────────────────────────────────────┼── release ── notify
 
 on:
   push:
@@ -264,52 +264,11 @@ jobs:
           retention-days: 90
 
   # ════════════════════════════════════════════════════════════════════════════
-  # Smoke test: verify bookworm tarball runs in a clean bookworm-slim container
-  # ════════════════════════════════════════════════════════════════════════════
-
-  docker-smoke-test:
-    needs: [publish]
-    name: docker smoke test (bookworm-amd64)
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Download bookworm artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: moxygen-bookworm-amd64.tar.gz
-          path: artifact/
-
-      - name: Extract tarball
-        run: |
-          mkdir -p install
-          tar xzf artifact/moxygen-bookworm-amd64.tar.gz -C install
-
-      - name: Smoke test in bookworm-slim
-        run: |
-          docker run --rm -v "$PWD/install:/mnt:ro" debian:bookworm-slim bash -c '
-            set -e
-            apt-get update -qq
-            apt-get install -y --no-install-recommends libunwind8 >/dev/null
-            echo "==> ldd /mnt/bin/moqrelayserver"
-            ldd /mnt/bin/moqrelayserver
-            if ldd /mnt/bin/moqrelayserver | grep -q "not found"; then
-              echo "ERROR: missing shared libraries"
-              exit 1
-            fi
-            echo "==> Running moqrelayserver --helpshort"
-            /mnt/bin/moqrelayserver --helpshort; RC=$?
-            if [ "$RC" -gt 1 ]; then
-              echo "ERROR: unexpected exit code $RC (crash or missing dep)"
-              exit 1
-            fi
-            echo "==> Smoke test passed"
-          '
-
-  # ════════════════════════════════════════════════════════════════════════════
   # Release: create/update snapshot-latest pre-release (main only, all green)
   # ════════════════════════════════════════════════════════════════════════════
 
   release:
-    needs: [build, build-pico, publish, docker-smoke-test]
+    needs: [build, build-pico, publish]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -332,7 +291,7 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
 
   notify:
-    needs: [build, build-pico, publish, docker-smoke-test, release]
+    needs: [build, build-pico, publish, release]
     if: always()
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/omoq-ci-pr.yml
+++ b/.github/workflows/omoq-ci-pr.yml
@@ -32,6 +32,14 @@ jobs:
             name: macos
             cache_prefix: ci-ninja-macos-15
           - os: ubuntu-22.04
+            name: pico (linux)
+            cache_prefix: ci-pico-ninja-ubuntu-22.04
+            picoquic: true
+          - os: macos-15
+            name: pico (macos)
+            cache_prefix: ci-pico-ninja-macos-15
+            picoquic: true
+          - os: ubuntu-22.04
             name: asan debug
             cache_prefix: ci-asan-ubuntu-22.04
     name: ${{ matrix.name }}
@@ -72,6 +80,7 @@ jobs:
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DBUILD_TESTING=ON \
+              ${{ matrix.picoquic && '-DBUILD_PICOQUIC=ON' || '' }} \
               -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/_install
           fi
 
@@ -93,63 +102,4 @@ jobs:
 
       - name: Install (smoke test)
         if: matrix.name != 'asan debug'
-        run: cmake --install _build
-
-  build-pico:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-22.04
-            name: linux
-            cache_prefix: ci-pico-ninja-ubuntu-22.04
-          - os: macos-15
-            name: macos
-            cache_prefix: ci-pico-ninja-macos-15
-    name: pico (${{ matrix.name }})
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install system dependencies
-        run: bash standalone/install-system-deps.sh
-
-      - name: Cache FetchContent downloads
-        uses: actions/cache@v4
-        with:
-          path: _build/_deps
-          key: ${{ matrix.cache_prefix }}-deps-${{ hashFiles('build/deps/github_hashes/**/*-rev.txt', 'standalone/patches/**') }}
-          restore-keys: |
-            ${{ matrix.cache_prefix }}-deps-
-
-      - name: Set up ccache
-        uses: hendrikmuhs/ccache-action@v1
-        with:
-          key: ${{ matrix.cache_prefix }}
-          max-size: 500M
-
-      - name: Configure
-        run: |
-          cmake -B _build -S standalone -G Ninja \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DBUILD_TESTING=ON \
-            -DBUILD_PICOQUIC=ON \
-            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/_install
-
-      - name: Build
-        run: cmake --build _build -j$(getconf _NPROCESSORS_ONLN)
-
-      - name: Test
-        run: ctest --test-dir _build --output-on-failure --output-junit test-results.xml
-
-      - name: Publish test results
-        uses: dorny/test-reporter@v1.9.1
-        if: success() || failure()
-        with:
-          name: "test pico (${{ matrix.name }})"
-          path: _build/test-results.xml
-          reporter: java-junit
-
-      - name: Install (smoke test)
         run: cmake --install _build

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -44,6 +44,7 @@ if(BUNDLE_DEPS)
     # mixing static gflags with shared glog causes dual-linkage crashes.
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         set(GFLAGS_SHARED OFF CACHE BOOL "" FORCE)
+        set(sodium_USE_STATIC_LIBS ON CACHE BOOL "" FORCE)
     endif()
     set(Boost_USE_STATIC_LIBS ON)
 endif()
@@ -106,7 +107,6 @@ if(BUNDLE_DEPS AND CMAKE_SYSTEM_NAME STREQUAL "Linux" AND TARGET glog::glog)
         set_target_properties(glog::glog PROPERTIES IMPORTED_LINK_INTERFACE_LIBRARIES "${_glog_link_libs}")
     endif()
 endif()
-find_package(fmt CONFIG REQUIRED)
 find_package(double-conversion CONFIG REQUIRED)
 find_package(Boost 1.70 REQUIRED COMPONENTS
     context filesystem program_options regex)
@@ -191,6 +191,14 @@ if(NOT fast_float_POPULATED)
 endif()
 set(FASTFLOAT_INCLUDE_DIR
     "${fast_float_SOURCE_DIR}/include" CACHE PATH "" FORCE)
+
+# fmt: build from source to guarantee static libfmt.a.
+# Ubuntu 22.04's libfmt-dev only ships .so; CONFIG-mode find_package
+# hardcodes .so paths, so CMAKE_FIND_LIBRARY_SUFFIXES can't help.
+FetchContent_Declare(fmt
+    GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+    GIT_TAG 10.2.1
+)
 
 # Allow overriding folly repo/rev via -DFOLLY_REPO_OVERRIDE and
 # -DFOLLY_REV_OVERRIDE
@@ -278,7 +286,7 @@ endif()
 # Also skip optional compression codecs not needed for moxygen.
 # Skip lzma unless libunwind is available (lzma is used for symbolization).
 set(_FETCHCONTENT_PROVIDED_DEPS folly fizz wangle mvfst proxygen GTest GMock
-    BZip2 LZ4 Snappy glog Glog)
+    BZip2 LZ4 Snappy glog Glog fmt)
 if(BUILD_PICOQUIC)
     list(APPEND _FETCHCONTENT_PROVIDED_DEPS picoquic)
 endif()
@@ -316,6 +324,14 @@ endif()
 # install path. Since they all share the same variable name, the first one
 # (folly) wins and the rest inherit "lib/cmake/folly". We force-set before
 # each add_subdirectory so configs land in lib/cmake/<dep>/.
+FetchContent_GetProperties(fmt)
+if(NOT fmt_POPULATED)
+    FetchContent_Populate(fmt)
+    apply_dep_patches(fmt "${fmt_SOURCE_DIR}")
+    set(CMAKE_INSTALL_DIR "lib/cmake/fmt" CACHE STRING "" FORCE)
+    add_subdirectory(${fmt_SOURCE_DIR} ${fmt_BINARY_DIR} ${_EXCLUDE_FLAG})
+endif()
+
 FetchContent_GetProperties(folly)
 if(NOT folly_POPULATED)
     FetchContent_Populate(folly)

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -286,7 +286,7 @@ endif()
 # Also skip optional compression codecs not needed for moxygen.
 # Skip lzma unless libunwind is available (lzma is used for symbolization).
 set(_FETCHCONTENT_PROVIDED_DEPS folly fizz wangle mvfst proxygen GTest GMock
-    BZip2 LZ4 Snappy glog Glog fmt)
+    BZip2 LZ4 Snappy glog Glog fmt Fmt)
 if(BUILD_PICOQUIC)
     list(APPEND _FETCHCONTENT_PROVIDED_DEPS picoquic)
 endif()
@@ -331,6 +331,11 @@ if(NOT fmt_POPULATED)
     set(CMAKE_INSTALL_DIR "lib/cmake/fmt" CACHE STRING "" FORCE)
     add_subdirectory(${fmt_SOURCE_DIR} ${fmt_BINARY_DIR} ${_EXCLUDE_FLAG})
 endif()
+# Tell folly's folly-deps.cmake that fmt is already configured so it
+# doesn't fall back to FindFmt.cmake (which would conflict with the
+# ALIAS target created by fmt's own CMakeLists.txt).
+set(fmt_FOUND TRUE)
+set(fmt_CONFIG "${fmt_SOURCE_DIR}/CMakeLists.txt")
 
 FetchContent_GetProperties(folly)
 if(NOT folly_POPULATED)


### PR DESCRIPTION
## Summary

Fixes the root cause of o-rly Docker image runtime link failures (openmoq/o-rly#53).

- **fmt**: Add as FetchContent dep — Ubuntu 22.04's `libfmt-dev` only ships `.so`, no `.a`. CONFIG-mode `find_package` hardcodes `.so` paths, so `CMAKE_FIND_LIBRARY_SUFFIXES` can't help. Building from source guarantees `libfmt.a`.
- **sodium**: Set `sodium_USE_STATIC_LIBS=ON` — `FindSodium.cmake` supports this; `libsodium-dev` ships `libsodium.a`.
- **docker-smoke-test**: New CI job downloads the bookworm tarball, runs `moqrelayserver` inside `debian:bookworm-slim` with only `libunwind8` installed. Verifies no missing shared libs and binary loads.

After this lands, the only dynamic deps should be: libc, libstdc++, libgcc_s, libm, liblzma, libunwind.

Verified locally: full BUNDLE_DEPS build produces a binary with no libfmt/libsodium in `ldd` output.

## Test plan

- [ ] CI build passes (fmt FetchContent + sodium static)
- [ ] docker-smoke-test job passes (ldd clean, binary runs)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/77)
<!-- Reviewable:end -->
