### PR TITLE
Fix cmake config: find_dependency(fmt) before folly

### DIFF
--- a/cmake/moxygen-config.cmake.in
+++ b/cmake/moxygen-config.cmake.in
@@ -12,6 +12,11 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
+# fmt must be found before folly: folly-targets.cmake references fmt::fmt in
+# Folly::folly_deps INTERFACE_LINK_LIBRARIES, and CMake >= 3.24 validates
+# imported-target dependencies at load time (before folly-config.cmake's own
+# find_dependency(fmt) is reached).
+find_dependency(fmt)
 find_dependency(folly)
 find_dependency(fizz)
 find_dependency(wangle)


### PR DESCRIPTION
## Summary

- Add `find_dependency(fmt)` before `find_dependency(folly)` in `moxygen-config.cmake.in`

`folly-targets.cmake` references `fmt::fmt` in `Folly::folly_deps` `INTERFACE_LINK_LIBRARIES`. CMake >= 3.24 validates imported-target dependencies at load time, before `folly-config.cmake`'s own `find_dependency(fmt)` is reached — causing configure failure for consumers of the installed cmake config (e.g. o-rly).

Tested locally: o-rly configure + build + 77/77 tests pass with cmake 4.2.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/78)
<!-- Reviewable:end -->
