### PR TITLE
Dispatch moxygen-update to o-rly on release

### DIFF
--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -244,6 +244,30 @@ jobs:
     if: always()
     runs-on: ubuntu-22.04
     steps:
+      # ── Dispatch submodule update to o-rly (on successful release) ──
+      - name: Generate o-rly app token
+        if: needs.release.result == 'success'
+        id: orly-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OMOQ_APP_ID }}
+          private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
+          repositories: o-rly
+
+      - name: Dispatch moxygen sync to o-rly
+        if: needs.release.result == 'success'
+        env:
+          GH_TOKEN: ${{ steps.orly-token.outputs.token }}
+        run: |
+          SHORT="${GITHUB_SHA:0:7}"
+          echo "Dispatching moxygen-update to o-rly (sha: ${SHORT}, run: ${{ github.run_id }})"
+          gh api repos/openmoq/o-rly/dispatches \
+            -f event_type=moxygen-update \
+            -f "client_payload[sha]=${GITHUB_SHA}" \
+            -f "client_payload[short_sha]=${SHORT}" \
+            -f "client_payload[run_id]=${{ github.run_id }}"
+
+      # ── Notifications ──
       - name: Notify Slack
         continue-on-error: true
         env:


### PR DESCRIPTION
## Summary

After a successful release in `ci main`, dispatch a `repository_dispatch` event
to `openmoq/o-rly` with `event_type: moxygen-update`. This triggers o-rly's
`moxygen sync` workflow to automatically update the `deps/moxygen` submodule
and create a PR.

- Generates an app token scoped to o-rly (`repositories: o-rly`)
- Payload: `{sha, short_sha, run_id}`
- Only fires when `release` job succeeds
- Placed in the `notify` job (runs last, `if: always()`)

Companion PR: openmoq/o-rly#59

## Merge and test plan

1. Merge openmoq/o-rly#59 first — test the receiver via manual workflow_dispatch
2. Then merge this PR to enable the automated dispatch
3. Next moxygen main push will trigger the full chain end-to-end

- [x] actionlint: clean
- [ ] Verify app token generation with `repositories: o-rly` works

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/82)
<!-- Reviewable:end -->
