### PR TITLE
Add gtest/gmock to install-system-deps.sh

### DIFF
--- a/standalone/install-system-deps.sh
+++ b/standalone/install-system-deps.sh
@@ -28,6 +28,8 @@ install_ubuntu() {
         libfmt-dev \
         zlib1g-dev \
         libc-ares-dev \
+        libgtest-dev \
+        libgmock-dev \
         gperf
 }
 
@@ -47,6 +49,8 @@ install_fedora() {
         fmt-devel \
         zlib-devel \
         c-ares-devel \
+        gtest-devel \
+        gmock-devel \
         gperf
     # ninja-build is available on Fedora but not CentOS/RHEL base repos.
     # Try to install it; if unavailable, warn with alternatives.


### PR DESCRIPTION
o-rly tests require GTest::gmock. Add libgtest-dev + libgmock-dev for Ubuntu/Debian and gtest-devel + gmock-devel for Fedora.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/89)
<!-- Reviewable:end -->
