### PR TITLE
Auto-delete sync/ branches after merge

### DIFF
--- a/.github/workflows/omoq-auto-merge-sync.yml
+++ b/.github/workflows/omoq-auto-merge-sync.yml
@@ -104,5 +104,5 @@ jobs:
           fi
 
           echo "Merging sync PR #${PR_NUM}..."
-          gh pr merge "${PR_NUM}" --merge --repo "${REPO}"
+          gh pr merge "${PR_NUM}" --merge --delete-branch --repo "${REPO}"
           echo "Merged PR #${PR_NUM}."


### PR DESCRIPTION
Add --delete-branch to gh pr merge in auto-merge workflow. Prevents stale sync/* branches from accumulating.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/92)
<!-- Reviewable:end -->
