### PR TITLE
fixes leaked moq-active-streams gauge

### DIFF
--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -3076,10 +3076,10 @@ class ObjectStreamCallback : public MoQObjectStreamCodec::ObjectCallback {
   }
 
   void endOfSubgroup(bool deliverCallback = false) {
-    if (subgroupCallback_) {
+    if (subscribeState_) {
       CHECK(session_) << "session_ is NULL in ObjectStreamCallback";
       // We only want to call this for SUBSCRIBEs and not FETCHes, which is
-      // why we condition on subgroupCallback_
+      // why we condition on subscribeState_
       session_->onSubscriptionStreamClosedByPeer();
     }
     if (deliverCallback && !isCancelled()) {
@@ -3093,6 +3093,8 @@ class ObjectStreamCallback : public MoQObjectStreamCodec::ObjectCallback {
       fetchState_->resetFetchCallback(session_);
     } else {
       subgroupCallback_.reset();
+      // Guard for idempotent reset() call
+      subscribeState_.reset();
     }
   }
   std::shared_ptr<MLogger> logger_ = nullptr;
@@ -3279,7 +3281,8 @@ folly::coro::Task<void> MoQSession::unidirectionalReadLoop(
       if (streamData->fin) {
         XLOG(DBG3) << "End of stream id=" << id << " sess=" << this;
         readHandle = nullptr;
-      } else if (result == MoQCodec::ParseResult::ERROR_TERMINATE) {
+      }
+      if (result == MoQCodec::ParseResult::ERROR_TERMINATE) {
         XLOG(ERR) << "Error parsing/consuming stream id=" << id
                   << " sess=" << this;
         dcb.reset(ResetStreamErrorCode::INTERNAL_ERROR);

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -2808,7 +2808,6 @@ class ObjectStreamCallback : public MoQObjectStreamCodec::ObjectCallback {
     }
 
     subscribeState_ = std::move(subscribeState);
-    session_->onSubscriptionStreamOpenedByPeer();
     auto callback = subscribeState_->getSubscribeCallback();
     if (!callback) {
       // This cannot happen in a PUBLISH_DONE flow, because
@@ -2823,6 +2822,7 @@ class ObjectStreamCallback : public MoQObjectStreamCodec::ObjectCallback {
     auto res = callback->beginSubgroup(group, subgroup, effectivePriority);
     if (res.hasValue()) {
       subgroupCallback_ = *res;
+      session_->onSubscriptionStreamOpenedByPeer();
     } else {
       return MoQCodec::ParseResult::ERROR_TERMINATE;
     }


### PR DESCRIPTION
Fix for https://github.com/openmoq/moqx/issues/127

Now a stream is considered open only after it is validated for all the Error scenarios.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/122)
<!-- Reviewable:end -->
