### PR TITLE
purge all

### DIFF
--- a/moxygen/relay/MoQCache.cpp
+++ b/moxygen/relay/MoQCache.cpp
@@ -1916,13 +1916,16 @@ bool MoQCache::evictOldestTrackIfNeeded() {
   return true;
 }
 
-void MoQCache::evictTrack(const FullTrackName& ftn) {
+size_t MoQCache::evictTrack(const FullTrackName& ftn) {
   auto it = cache_.find(ftn);
   if (it == cache_.end()) {
-    return;
+    return 0;
   }
 
   auto& track = *it->second;
+  // Stamp evicted before erasing so any in-flight SubscribeWriteback/
+  // FetchReadback objects discover the flag and stop caching.
+  track.evicted = true;
   // Remove from LRU if present
   if (track.lruIter_.hasValue()) {
     trackLRU_.erase(*track.lruIter_);
@@ -1937,6 +1940,35 @@ void MoQCache::evictTrack(const FullTrackName& ftn) {
   // Remove from cache
   cache_.erase(it);
   XLOG(DBG1) << "Evicted track: " << ftn;
+  return 1;
+}
+
+size_t MoQCache::purge(const TrackNamespace& ns) {
+  // Snapshot to avoid iterator invalidation when evictTrack() modifies cache_.
+  std::vector<FullTrackName> matching;
+  for (auto& [ftn, _] : cache_) {
+    if (ftn.trackNamespace == ns) {
+      matching.push_back(ftn);
+    }
+  }
+  size_t count = 0;
+  for (auto& trackName : matching) {
+    count += evictTrack(trackName);
+  }
+  return count;
+}
+
+size_t MoQCache::purge() {
+  // Snapshot keys to avoid iterator invalidation during eviction.
+  std::vector<FullTrackName> all;
+  all.reserve(cache_.size());
+  for (auto& [ftn, _] : cache_) {
+    all.push_back(ftn);
+  }
+  for (auto& trackName : all) {
+    evictTrack(trackName);
+  }
+  return all.size();
 }
 
 void MoQCache::evictOldestGroupsIfNeeded(CacheTrack& track) {

--- a/moxygen/relay/MoQCache.h
+++ b/moxygen/relay/MoQCache.h
@@ -68,6 +68,18 @@ class MoQCache {
     totalCachedBytes_ = 0;
   }
 
+  // Force-evicts a specific track unconditionally. Returns 1 if found, 0 if
+  // not.
+  size_t purge(const FullTrackName& ftn) {
+    return evictTrack(ftn);
+  }
+
+  // Force-evicts all tracks in the given namespace unconditionally.
+  size_t purge(const TrackNamespace& ns);
+
+  // Force-evicts all cached tracks unconditionally.
+  size_t purge();
+
   bool hasTrack(const FullTrackName& ftn) const {
     return cache_.contains(ftn);
   }
@@ -366,7 +378,7 @@ class MoQCache {
 
   // Eviction methods
   bool evictOldestTrackIfNeeded();
-  void evictTrack(const FullTrackName& ftn);
+  size_t evictTrack(const FullTrackName& ftn);
   void evictOldestGroupsIfNeeded(CacheTrack& track);
   void evictGroup(CacheTrack& track, uint64_t groupID);
   bool evictForByteLimitIfNeeded();

--- a/moxygen/relay/test/MoQCacheTests.cpp
+++ b/moxygen/relay/test/MoQCacheTests.cpp
@@ -2687,6 +2687,101 @@ CO_TEST_F(MoQCacheTest, TestMinEvictionBytesLowWatermark) {
   co_return;
 }
 
+// ============================================================================
+// Purge tests
+// ============================================================================
+
+// purge(ftn): track evicted unconditionally regardless of live state.
+CO_TEST_F(MoQCacheTest, PurgeSpecificTrack) {
+  auto wb = cache_.getSubscribeWriteback(kTestTrackName, trackConsumer_);
+  wb->datagram(ObjectHeader(0, 0, 0, 0, 5), makeBuf(5));
+  // Keep writeback alive — live track must still be evicted.
+
+  EXPECT_EQ(cache_.purge(kTestTrackName), 1u);
+  EXPECT_FALSE(cache_.hasTrack(kTestTrackName));
+  co_return;
+}
+
+// purge(ftn): track not in cache → no-op, returns 0.
+CO_TEST_F(MoQCacheTest, PurgeSpecificTrackNotCached) {
+  const FullTrackName absent{TrackNamespace{{"ghost"}}, "track"};
+  EXPECT_EQ(cache_.purge(absent), 0u);
+  co_return;
+}
+
+// purge(): one live + two evictable → all three evicted unconditionally.
+CO_TEST_F(MoQCacheTest, PurgeMixedLiveAndEvictable) {
+  const FullTrackName ftLive{TrackNamespace{{"x"}}, "live"};
+  const FullTrackName ftDead1{TrackNamespace{{"x"}}, "dead1"};
+  const FullTrackName ftDead2{TrackNamespace{{"x"}}, "dead2"};
+
+  auto wbLive = cache_.getSubscribeWriteback(ftLive, trackConsumer_);
+  wbLive->datagram(ObjectHeader(0, 0, 0, 0, 5), makeBuf(5));
+
+  for (auto& ftn : {ftDead1, ftDead2}) {
+    auto wb = cache_.getSubscribeWriteback(ftn, trackConsumer_);
+    wb->datagram(ObjectHeader(0, 0, 0, 0, 5), makeBuf(5));
+  }
+
+  EXPECT_EQ(cache_.purge(), 3u);
+  EXPECT_EQ(cache_.size(), 0u);
+  co_return;
+}
+
+// purge(): empty cache → no-op, returns 0.
+CO_TEST_F(MoQCacheTest, PurgeAllEmptyCache) {
+  EXPECT_EQ(cache_.purge(), 0u);
+  co_return;
+}
+
+// purge(ns): evicts matching tracks, leaves others intact.
+CO_TEST_F(MoQCacheTest, PurgeNamespaceEvictsAllMatchingTracks) {
+  const FullTrackName ftA{TrackNamespace{{"foo"}}, "track-a"};
+  const FullTrackName ftB{TrackNamespace{{"foo"}}, "track-b"};
+  const FullTrackName ftOther{TrackNamespace{{"bar"}}, "other"};
+
+  for (auto& ftn : {ftA, ftB, ftOther}) {
+    auto wb = cache_.getSubscribeWriteback(ftn, trackConsumer_);
+    wb->datagram(ObjectHeader(0, 0, 0, 0, 5), makeBuf(5));
+  }
+
+  EXPECT_EQ(cache_.purge(TrackNamespace{{"foo"}}), 2u);
+  EXPECT_EQ(cache_.size(), 1u);
+  EXPECT_TRUE(cache_.hasTrack(ftOther));
+  EXPECT_FALSE(cache_.hasTrack(ftA));
+  EXPECT_FALSE(cache_.hasTrack(ftB));
+  co_return;
+}
+
+// purge(ns): live tracks in namespace evicted unconditionally.
+CO_TEST_F(MoQCacheTest, PurgeNamespaceAlsoEvictsLiveTracks) {
+  const FullTrackName ftLive{TrackNamespace{{"ns"}}, "live"};
+  const FullTrackName ftDead{TrackNamespace{{"ns"}}, "dead"};
+
+  auto wbLive = cache_.getSubscribeWriteback(ftLive, trackConsumer_);
+  wbLive->datagram(ObjectHeader(0, 0, 0, 0, 5), makeBuf(5));
+  {
+    auto wbDead = cache_.getSubscribeWriteback(ftDead, trackConsumer_);
+    wbDead->datagram(ObjectHeader(0, 0, 0, 0, 5), makeBuf(5));
+  }
+
+  EXPECT_EQ(cache_.purge(TrackNamespace{{"ns"}}), 2u);
+  EXPECT_FALSE(cache_.hasTrack(ftLive));
+  EXPECT_FALSE(cache_.hasTrack(ftDead));
+  co_return;
+}
+
+// purge(ns): unknown namespace → safe no-op.
+CO_TEST_F(MoQCacheTest, PurgeNamespaceUnknownIsNoop) {
+  auto wb = cache_.getSubscribeWriteback(kTestTrackName, trackConsumer_);
+  wb->datagram(ObjectHeader(0, 0, 0, 0, 5), makeBuf(5));
+  wb.reset();
+
+  EXPECT_EQ(cache_.purge(TrackNamespace{{"nonexistent"}}), 0u);
+  EXPECT_TRUE(cache_.hasTrack(kTestTrackName));
+  co_return;
+}
+
 // Regression test: two SubscribeWritebacks for the same track (simulating an
 // upstream reconnect). When the old writeback is destroyed, the track must
 // remain non-evictable because the new writeback is still active.


### PR DESCRIPTION
Adds a safe purge api to evict namespace and tracknames
moqx PR: https://github.com/openmoq/moqx/pull/118
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/126)
<!-- Reviewable:end -->
