### PR TITLE
pico: set path on MoQSession from WebTransport CONNECT request

### DIFF
--- a/moxygen/openmoq/transport/pico/MoQPicoServerBase.cpp
+++ b/moxygen/openmoq/transport/pico/MoQPicoServerBase.cpp
@@ -568,6 +568,14 @@ int MoQPicoServerBase::onWebTransportConnectImpl(
   auto moqSession = createSession(webTransport, executor_);
   webTransport->setHandler(moqSession.get());
 
+  // Set path from the HTTP/3 CONNECT request. Authority is not set because
+  // h3zero_header_parts_t does not expose the :authority pseudo-header.
+  const auto& hdr = streamCtx->ps.stream_state.header;
+  if (hdr.path && hdr.path_length > 0) {
+    moqSession->setPath(
+        std::string(reinterpret_cast<const char*>(hdr.path), hdr.path_length));
+  }
+
   // Negotiate MOQT version via WebTransport protocol negotiation.
   // The client sends wt-available-protocols, we select from our supported
   // versions. Note: picowt_select_wt_protocol expects ALPN format (e.g.


### PR DESCRIPTION
MoQServer.cpp (proxygen path) calls setPath on the session from the HTTP request. The pico WebTransport path was missing this. Set path from streamCtx->ps.stream_state.header.path in onWebTransportConnectImpl.

Authority is not set because h3zero_header_parts_t does not expose the :authority pseudo-header.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/127)
<!-- Reviewable:end -->
