### PR TITLE
relay: add subscriber/object counters to MoQForwarder and cache stats to MoQCache

### DIFF
--- a/moxygen/relay/MoQCache.cpp
+++ b/moxygen/relay/MoQCache.cpp
@@ -443,6 +443,7 @@ class MoQCache::SubgroupWriteback : public SubgroupConsumer {
     auto cPayload = payload ? payload->clone() : nullptr;
     auto cacheRes = cache_.cacheObjectAndUpdateBytes(
         cacheGroup_,
+        cacheTrack_,
         subgroup_,
         objID,
         ObjectStatus::NORMAL,
@@ -479,6 +480,7 @@ class MoQCache::SubgroupWriteback : public SubgroupConsumer {
     }
     auto cacheRes = cache_.cacheObjectAndUpdateBytes(
         cacheGroup_,
+        cacheTrack_,
         subgroup_,
         objectID,
         ObjectStatus::NORMAL,
@@ -539,6 +541,7 @@ class MoQCache::SubgroupWriteback : public SubgroupConsumer {
     }
     auto cacheRes = cache_.cacheObjectAndUpdateBytes(
         cacheGroup_,
+        cacheTrack_,
         subgroup_,
         endOfGroupObjectID,
         ObjectStatus::END_OF_GROUP,
@@ -563,6 +566,7 @@ class MoQCache::SubgroupWriteback : public SubgroupConsumer {
     }
     auto cacheRes = cache_.cacheObjectAndUpdateBytes(
         cacheGroup_,
+        cacheTrack_,
         subgroup_,
         endOfTrackObjectID,
         ObjectStatus::END_OF_TRACK,
@@ -669,6 +673,7 @@ class MoQCache::SubscribeWriteback : public TrackConsumer {
     }
     auto cacheRes = cache_.cacheObjectAndUpdateBytes(
         track_.getOrCreateGroup(header.group, &cache_),
+        track_,
         header.subgroup,
         header.id,
         header.status,
@@ -700,6 +705,7 @@ class MoQCache::SubscribeWriteback : public TrackConsumer {
     }
     auto cacheRes = cache_.cacheObjectAndUpdateBytes(
         track_.getOrCreateGroup(header.group, &cache_),
+        track_,
         header.subgroup,
         header.id,
         header.status,
@@ -1074,6 +1080,7 @@ class MoQCache::FetchWriteback : public FetchConsumer {
     auto& group = fetchRangeIt_.track->getOrCreateGroup(groupID);
     auto cacheRes = cache_.cacheObjectAndUpdateBytes(
         group,
+        *fetchRangeIt_.track,
         subgroupID,
         objectID,
         status,
@@ -1962,6 +1969,7 @@ bool MoQCache::evictForByteLimitIfNeeded() {
 folly::Expected<folly::Unit, MoQPublishError>
 MoQCache::cacheObjectAndUpdateBytes(
     CacheGroup& group,
+    CacheTrack& track,
     uint64_t subgroup,
     uint64_t objectID,
     ObjectStatus status,
@@ -1987,9 +1995,33 @@ MoQCache::cacheObjectAndUpdateBytes(
       XCHECK_GE(totalCachedBytes_, oldGroupBytes - group.totalBytes);
       totalCachedBytes_ -= oldGroupBytes - group.totalBytes;
     }
+    track.lastWrite = now;
     evictForByteLimitIfNeeded();
   }
   return res;
+}
+
+std::vector<MoQCache::TrackStats> MoQCache::getTrackStats() const {
+  std::vector<TrackStats> result;
+  result.reserve(cache_.size());
+  for (const auto& [ftn, track] : cache_) {
+    TrackStats ts;
+    ts.name = ftn;
+    ts.endOfTrack = track->endOfTrack;
+    ts.lastWrite = track->lastWrite;
+    ts.groups.reserve(track->groups.size());
+    for (const auto& [groupId, group] : track->groups) {
+      ts.groups.push_back({groupId, group->objects.size()});
+    }
+    std::sort(
+        ts.groups.begin(),
+        ts.groups.end(),
+        [](const GroupStats& a, const GroupStats& b) {
+          return a.groupId < b.groupId;
+        });
+    result.push_back(std::move(ts));
+  }
+  return result;
 }
 
 } // namespace moxygen

--- a/moxygen/relay/MoQCache.h
+++ b/moxygen/relay/MoQCache.h
@@ -138,6 +138,29 @@ class MoQCache {
     clock_ = std::move(clock);
   }
 
+  // Returns total payload bytes currently held in the cache.
+  size_t totalCachedBytes() const {
+    return totalCachedBytes_;
+  }
+
+  // Per-group stats for getTrackStats().
+  struct GroupStats {
+    uint64_t groupId;
+    size_t objects;
+  };
+
+  // Per-track stats for getTrackStats().
+  struct TrackStats {
+    FullTrackName name;
+    bool endOfTrack;
+    TimePoint lastWrite;
+    std::vector<GroupStats> groups; // sorted by groupId ascending
+  };
+
+  // Returns a snapshot of all cached tracks and their group/object counts.
+  // Groups within each track are returned in ascending groupId order.
+  std::vector<TrackStats> getTrackStats() const;
+
   // Entry for single cached object
   struct CacheEntry {
     CacheEntry(
@@ -222,6 +245,8 @@ class MoQCache {
     std::optional<std::chrono::milliseconds> maxCacheDuration;
     // Track-level extensions to include in FetchOk
     Extensions extensions;
+    // Time of the most recently cached object in this track
+    TimePoint lastWrite{TimePoint::min()};
 
     folly::Expected<folly::Unit, MoQPublishError> updateLargest(
         AbsoluteLocation current,
@@ -341,9 +366,10 @@ class MoQCache {
   void evictGroup(CacheTrack& track, uint64_t groupID);
   bool evictForByteLimitIfNeeded();
 
-  // Wraps cacheObject() + byte accounting + eviction check
+  // Wraps cacheObject() + byte accounting + eviction check + lastWrite update
   folly::Expected<folly::Unit, MoQPublishError> cacheObjectAndUpdateBytes(
       CacheGroup& group,
+      CacheTrack& track,
       uint64_t subgroup,
       uint64_t objectID,
       ObjectStatus status,

--- a/moxygen/relay/MoQForwarder.cpp
+++ b/moxygen/relay/MoQForwarder.cpp
@@ -514,6 +514,7 @@ folly::Expected<folly::Unit, MoQPublishError> MoQForwarder::objectStream(
     Payload payload,
     bool lastInGroup) {
   updateLargest(header.group, header.id);
+  countReceivedObject(header.group);
   return forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
     if (!checkRange(*sub) || !sub->checkShouldForward()) {
       return;
@@ -530,6 +531,7 @@ folly::Expected<folly::Unit, MoQPublishError> MoQForwarder::datagram(
     Payload payload,
     bool lastInGroup) {
   updateLargest(header.group, header.id);
+  countReceivedObject(header.group);
   return forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
     if (!checkRange(*sub) || !sub->checkShouldForward()) {
       return;
@@ -764,6 +766,15 @@ void MoQForwarder::SubgroupForwarder::updateLargest(
     uint64_t object) {
   if (forwarder_) {
     forwarder_->updateLargest(group, object);
+    forwarder_->countReceivedObject(group);
+  }
+}
+
+void MoQForwarder::countReceivedObject(uint64_t groupID) {
+  totalObjectsReceived_++;
+  if (groupID != lastGroupSeen_) {
+    lastGroupSeen_ = groupID;
+    totalGroupsReceived_++;
   }
 }
 

--- a/moxygen/relay/MoQForwarder.h
+++ b/moxygen/relay/MoQForwarder.h
@@ -294,6 +294,18 @@ class MoQForwarder : public TrackConsumer {
     return forwardingSubscribers_;
   }
 
+  size_t subscriberCount() const {
+    return subscribers_.size();
+  }
+
+  uint64_t totalGroupsReceived() const {
+    return totalGroupsReceived_;
+  }
+
+  uint64_t totalObjectsReceived() const {
+    return totalObjectsReceived_;
+  }
+
  private:
   static Payload maybeClone(const Payload& payload);
 
@@ -333,7 +345,19 @@ class MoQForwarder : public TrackConsumer {
   // the upstream Largest Group advances (indicating the request was fulfilled).
   std::optional<uint64_t> outstandingNewGroupRequest_{};
   std::shared_ptr<Callback> callback_;
+  // Increments totalObjectsReceived_ and, when the group changes,
+  // totalGroupsReceived_.  Call once per incoming object regardless of delivery
+  // mode (subgroup stream, objectStream, datagram).
+  void countReceivedObject(uint64_t groupID);
+
   uint64_t forwardingSubscribers_{0};
+  uint64_t totalGroupsReceived_{0};
+  uint64_t totalObjectsReceived_{0};
+  // NOTE: counts distinct group transitions, not distinct group IDs.
+  // If subgroups for a group arrive interleaved with another group (e.g. under
+  // NewestFirst delivery or due to retransmission), a group may be counted more
+  // than once.  This is a best-effort counter for diagnostics only.
+  uint64_t lastGroupSeen_{std::numeric_limits<uint64_t>::max()};
   bool draining_{false};
 };
 

--- a/moxygen/relay/test/MoQCacheTests.cpp
+++ b/moxygen/relay/test/MoQCacheTests.cpp
@@ -420,6 +420,21 @@ CO_TEST_F(MoQCacheTest, TestFetchAllHit) {
       co_await cache_.fetch(getFetch({0, 0}, {0, 10}), consumer_, upstream_);
   EXPECT_TRUE(res.hasValue());
   EXPECT_EQ(res.value()->fetchOk().endLocation, (AbsoluteLocation{0, 10}));
+
+  // Verify cache stat APIs: 10 objects × 100 bytes each in 1 group
+  EXPECT_EQ(cache_.totalCachedBytes(), 1000u);
+  auto stats = cache_.getTrackStats();
+  EXPECT_EQ(stats.size(), 1u);
+  if (!stats.empty()) {
+    EXPECT_EQ(stats[0].name, kTestTrackName);
+    EXPECT_FALSE(stats[0].endOfTrack);
+    EXPECT_EQ(stats[0].groups.size(), 1u);
+    if (!stats[0].groups.empty()) {
+      EXPECT_EQ(stats[0].groups[0].groupId, 0u);
+      EXPECT_EQ(stats[0].groups[0].objects, 10u);
+    }
+    EXPECT_GT(stats[0].lastWrite.time_since_epoch().count(), 0);
+  }
 }
 CO_TEST_F(MoQCacheTest, TestFetchAllHitEOG) {
   populateCacheRange({0, 0}, {0, 11}, 10, 1, 1, true);

--- a/moxygen/relay/test/MoQRelayTest.cpp
+++ b/moxygen/relay/test/MoQRelayTest.cpp
@@ -2881,4 +2881,42 @@ TEST_F(MoQRelayTest, DuplicateSubgroupSkipsTombstonedSubscriber) {
   removeSession(subB);
 }
 
+// Standalone tests for MoQForwarder counter APIs (no relay needed)
+TEST(MoQForwarderCounterTest, InitialCountersAndSubscriberCount) {
+  MoQForwarder fwd(kTestTrackName);
+
+  EXPECT_EQ(fwd.subscriberCount(), 0u);
+  EXPECT_EQ(fwd.totalObjectsReceived(), 0u);
+  EXPECT_EQ(fwd.totalGroupsReceived(), 0u);
+
+  // beginSubgroup returns CANCELLED when there are no subscribers: intentional
+  // back-pressure so the publisher stops sending.
+  auto sg_res = fwd.beginSubgroup(0, 0, kDefaultPriority);
+  EXPECT_FALSE(sg_res.hasValue());
+  EXPECT_EQ(sg_res.error().code, MoQPublishError::CANCELLED);
+
+  // Counters are unaffected by the failed beginSubgroup
+  EXPECT_EQ(fwd.totalObjectsReceived(), 0u);
+  EXPECT_EQ(fwd.totalGroupsReceived(), 0u);
+}
+
+TEST(MoQForwarderCounterTest, ObjectStreamAndDatagramCounted) {
+  MoQForwarder fwd(kTestTrackName);
+
+  // objectStream: group 0, object 0
+  fwd.objectStream(ObjectHeader(0, 0, 0), makeBuf());
+  EXPECT_EQ(fwd.totalObjectsReceived(), 1u);
+  EXPECT_EQ(fwd.totalGroupsReceived(), 1u);
+
+  // datagram: same group 0, object 1 (no new group)
+  fwd.datagram(ObjectHeader(0, 0, 1), makeBuf());
+  EXPECT_EQ(fwd.totalObjectsReceived(), 2u);
+  EXPECT_EQ(fwd.totalGroupsReceived(), 1u);
+
+  // datagram: group 1 (new group)
+  fwd.datagram(ObjectHeader(1, 0, 0), makeBuf());
+  EXPECT_EQ(fwd.totalObjectsReceived(), 3u);
+  EXPECT_EQ(fwd.totalGroupsReceived(), 2u);
+}
+
 } // namespace moxygen::test


### PR DESCRIPTION
MoQForwarder:
- Add subscriberCount(), totalGroupsReceived(), totalObjectsReceived() accessors
- Add countReceivedObject() helper called from SubgroupForwarder::updateLargest, objectStream(), and datagram() to track objects flowing through the forwarder
- Note: group counting is best-effort; interleaved subgroups may double-count

MoQCache:
- Add lastWrite timestamp to CacheTrack, updated on every cacheObjectAndUpdateBytes()
- Add totalCachedBytes() accessor (was already tracked privately)
- Add TrackStats/GroupStats structs and getTrackStats() for external inspection

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/128)
<!-- Reviewable:end -->
