### PR TITLE
pico: update copyright headers to OpenMOQ and Apache 2.0

### DIFF
--- a/moxygen/openmoq/transport/pico/MoQPicoQuicEventBaseClient.cpp
+++ b/moxygen/openmoq/transport/pico/MoQPicoQuicEventBaseClient.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/MoQPicoQuicEventBaseClient.h
+++ b/moxygen/openmoq/transport/pico/MoQPicoQuicEventBaseClient.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/MoQPicoQuicEventBaseServer.cpp
+++ b/moxygen/openmoq/transport/pico/MoQPicoQuicEventBaseServer.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/MoQPicoQuicEventBaseServer.h
+++ b/moxygen/openmoq/transport/pico/MoQPicoQuicEventBaseServer.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/MoQPicoQuicServer.cpp
+++ b/moxygen/openmoq/transport/pico/MoQPicoQuicServer.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/MoQPicoQuicServer.h
+++ b/moxygen/openmoq/transport/pico/MoQPicoQuicServer.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/MoQPicoServerBase.cpp
+++ b/moxygen/openmoq/transport/pico/MoQPicoServerBase.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/MoQPicoServerBase.h
+++ b/moxygen/openmoq/transport/pico/MoQPicoServerBase.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/PicoConnectionContext.h
+++ b/moxygen/openmoq/transport/pico/PicoConnectionContext.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/PicoH3WebTransport.cpp
+++ b/moxygen/openmoq/transport/pico/PicoH3WebTransport.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/PicoH3WebTransport.h
+++ b/moxygen/openmoq/transport/pico/PicoH3WebTransport.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/PicoProtocolDispatcher.h
+++ b/moxygen/openmoq/transport/pico/PicoProtocolDispatcher.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/PicoQuicExecutor.cpp
+++ b/moxygen/openmoq/transport/pico/PicoQuicExecutor.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/PicoQuicExecutor.h
+++ b/moxygen/openmoq/transport/pico/PicoQuicExecutor.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/PicoQuicSocketHandler.cpp
+++ b/moxygen/openmoq/transport/pico/PicoQuicSocketHandler.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/PicoQuicSocketHandler.h
+++ b/moxygen/openmoq/transport/pico/PicoQuicSocketHandler.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/PicoQuicStatsCallback.h
+++ b/moxygen/openmoq/transport/pico/PicoQuicStatsCallback.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/PicoQuicWebTransport.cpp
+++ b/moxygen/openmoq/transport/pico/PicoQuicWebTransport.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/PicoQuicWebTransport.h
+++ b/moxygen/openmoq/transport/pico/PicoQuicWebTransport.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/PicoTransportConfig.h
+++ b/moxygen/openmoq/transport/pico/PicoTransportConfig.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/PicoWebTransportBase.cpp
+++ b/moxygen/openmoq/transport/pico/PicoWebTransportBase.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/PicoWebTransportBase.h
+++ b/moxygen/openmoq/transport/pico/PicoWebTransportBase.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/sample/PicoEventBaseRelayServer.cpp
+++ b/moxygen/openmoq/transport/pico/sample/PicoEventBaseRelayServer.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/sample/PicoRelayServer.cpp
+++ b/moxygen/openmoq/transport/pico/sample/PicoRelayServer.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/moxygen/openmoq/transport/pico/sample/PicoTextClient.cpp
+++ b/moxygen/openmoq/transport/pico/sample/PicoTextClient.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * This source code is licensed under the MIT license found in the
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 


### PR DESCRIPTION
Replace stale Meta Platforms copyright with OpenMOQ, Inc. and update MIT license references to Apache 2.0 across all files in moxygen/openmoq/.

Both were an oversight — all pico QUIC implementation was developed by OpenMOQ and was never Meta or MIT-licensed code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/129)
<!-- Reviewable:end -->
