### PR TITLE
Add CODEOWNERS and SECURITY.md

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # owners are auto-tagged for review when a PR opens, but the approving
 # review may come from any qualified reviewer.
 
-* @afrind @gmarzot @peterchave @suhasHere
+* @afrind @akash-a-n @gmarzot @michalhosna @mondain @Oxyd @peterchave @suhasHere @TimEvens

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# CODEOWNERS — auto-requests reviews from the openmoq merge group.
+#
+# Branch protection requires one approving review (from any user with write
+# access) and restricts the merge button to the users listed below. Code
+# owners are auto-tagged for review when a PR opens, but the approving
+# review may come from any qualified reviewer.
+
+* @afrind @gmarzot @peterchave

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # owners are auto-tagged for review when a PR opens, but the approving
 # review may come from any qualified reviewer.
 
-* @afrind @gmarzot @peterchave
+* @afrind @gmarzot @peterchave @suhasHere

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in this fork of
+moxygen, please report it privately. **Do not open a public GitHub issue
+for security reports.**
+
+Email: security@openmoq.org
+
+Please include:
+- A description of the issue and its potential impact
+- Steps to reproduce, or a proof of concept
+- Affected version(s) (commit SHA or release tag)
+- Any suggested mitigations
+
+We will acknowledge receipt within 5 business days and aim to provide an
+initial assessment within 10 business days.
+
+## Upstream
+
+This repository tracks `facebookexperimental/moxygen`. Vulnerabilities that
+originate upstream may also be reported to Meta's security disclosure
+process; we will coordinate as appropriate.
+
+## Supported Versions
+
+Security fixes are applied to the `main` branch and the most recent
+`snapshot-latest` build. Older builds are not supported.


### PR DESCRIPTION
## Summary

Adds governance files alongside the merge restrictions already applied to `main` branch protection.

- **CODEOWNERS** — `* @afrind @gmarzot @peterchave`. Auto-tags the merge group for review on every PR. Branch protection does not require code-owner approval (any write-tier reviewer's approval counts), so SMEs like @suhasHere or @akash-a-n can still be the effective reviewer for their areas; the merge button itself is gated by the `restrictions` allowlist.
- **SECURITY.md** — private vulnerability reporting via `security@openmoq.org`, with a note about coordinating with upstream.

No code or workflow changes.

## Test plan

- [ ] CI matrix (linux / macos / asan debug) passes (no functional changes; should be a no-op)
- [ ] After merge: confirm new PRs auto-request review from the three code owners

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/134)
<!-- Reviewable:end -->
