### PR TITLE
ci: cap parallel build at -j6 in publish to avoid linker OOM

### DIFF
--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -95,7 +95,10 @@ jobs:
             "${ASAN_FLAGS[@]}" "${EXTRA_FLAGS[@]}"
 
       - name: Build
-        run: cmake --build _build -j$(getconf _NPROCESSORS_ONLN)
+        # Cap parallel jobs to avoid OOM during the link phase (publish
+        # build OOMed at -j8 on the 16 GB Linode runner during MoQTests
+        # link). -j6 keeps most throughput while leaving headroom.
+        run: cmake --build _build -j6
 
       - name: Test
         env:
@@ -210,7 +213,10 @@ jobs:
             "${EXTRA_FLAGS[@]}"
 
       - name: Build
-        run: cmake --build _build -j$(getconf _NPROCESSORS_ONLN)
+        # Cap parallel jobs to avoid OOM during the link phase (publish
+        # build OOMed at -j8 on the 16 GB Linode runner during MoQTests
+        # link). -j6 keeps most throughput while leaving headroom.
+        run: cmake --build _build -j6
 
       - name: Install
         run: cmake --install _build


### PR DESCRIPTION
## Summary

The publish (bookworm-amd64) job in [run 24370058293](https://github.com/openmoq/moxygen/actions/runs/24370058293/job/71186071570) OOMed at \`-j8\` (default nproc) on the self-hosted Linode runner — exit code 137 (SIGKILL/OOM) at step 1716/1757, just past the link-heavy phase.

### Root cause

- Compile-phase memory is fine: ~500 MB per cc1plus, 8 parallel = ~4 GB total
- Link-phase memory is much higher: large executables (MoQTests, MoQRelayTest, etc.) pull in dozens of static archives and can peak at 3-4 GB per linker
- 8 parallel linkers × ~3 GB = 24 GB > 16 GB host RAM → kernel OOM-killer fires

Container has no memory limits (\`Memory: 0\` confirmed via docker inspect), and host has 16 GB total. The bottleneck is real, not artificial.

### Fix

Cap parallel jobs at \`-j6\` for the ci-main build/publish jobs. Keeps most throughput while leaving ~3-4 GB headroom for linker spikes. PR jobs are unchanged — they haven't been observed OOMing.

## Test plan

- [ ] CI passes on PR
- [ ] After merge: confirm next ci main publish (bookworm-amd64) succeeds

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/137)
<!-- Reviewable:end -->
