### PR TITLE
ci: revert -j6 cap on verify build; keep only on publish

### DIFF
--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -95,10 +95,7 @@ jobs:
             "${ASAN_FLAGS[@]}" "${EXTRA_FLAGS[@]}"
 
       - name: Build
-        # Cap parallel jobs to avoid OOM during the link phase (publish
-        # build OOMed at -j8 on the 16 GB Linode runner during MoQTests
-        # link). -j6 keeps most throughput while leaving headroom.
-        run: cmake --build _build -j6
+        run: cmake --build _build -j$(getconf _NPROCESSORS_ONLN)
 
       - name: Test
         env:


### PR DESCRIPTION
Follow-up to #137 — only the publish job was OOMing, but the previous PR also throttled the verify build. Restore verify to default nproc parallelism.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/138)
<!-- Reviewable:end -->
