### PR TITLE
Register picoquic congestion algorithms before lookup

### DIFF
--- a/moxygen/openmoq/transport/pico/MoQPicoServerBase.cpp
+++ b/moxygen/openmoq/transport/pico/MoQPicoServerBase.cpp
@@ -352,6 +352,9 @@ bool MoQPicoServerBase::createQuicContext() {
     return false;
   }
 
+  picoquic_register_all_congestion_control_algorithms();
+  XLOG(INFO) << "Registered picoquic congestion control algorithms for name lookup";
+
   picoquic_set_alpn_select_fn_v2(quic_, alpnSelectCallback);
   picoquic_set_cookie_mode(quic_, 2);
   if (picoquic_get_congestion_algorithm(transportConfig_.ccAlgo.c_str()) ==


### PR DESCRIPTION
Without this setting congestion control algo will default to newreno

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/139)
<!-- Reviewable:end -->
