### PR TITLE
fix: set --target SHA on snapshot-latest release

### DIFF
--- a/openmoq/scripts/publish-artifacts.sh
+++ b/openmoq/scripts/publish-artifacts.sh
@@ -129,6 +129,7 @@ else
   # Create as pre-release so it doesn't show as "Latest release"
   # shellcheck disable=SC2086
   gh release create "$TAG" \
+    --target "$SHA" \
     --title "Latest build ($SHORT_SHA)" \
     --prerelease \
     --notes "$(cat <<EOF


### PR DESCRIPTION
One-line fix: add `--target "$SHA"` to `gh release create` in publish-artifacts.sh.

Without it, `target_commitish` defaults to `"main"` (the branch name). The version-release workflow reads this field to tag versioned releases, and gets whatever HEAD is at that moment instead of the commit the snapshot was built from.

Needed before moqx cuts a release branch — the version-release workflow must tag the exact SHA the artifacts were built from.

## Test plan

- [ ] CI passes
- [ ] After merge: next ci-main publish creates snapshot-latest with `target_commitish` set to the full SHA (verify via `gh api repos/openmoq/moxygen/releases --jq '.[] | select(.tag_name == "snapshot-latest") | .target_commitish'`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/145)
<!-- Reviewable:end -->
