### PR TITLE
fix: MoQForwarder::Subscriber::onPublishOk now updates forwardingSubscribers_

### DIFF
--- a/moxygen/relay/MoQForwarder.cpp
+++ b/moxygen/relay/MoQForwarder.cpp
@@ -672,6 +672,16 @@ void MoQForwarder::Subscriber::setParam(const TrackRequestParameter& param) {
   }
 }
 
+void MoQForwarder::Subscriber::updateForwardState(bool newForward) {
+  auto wasForwarding = shouldForward;
+  shouldForward = newForward;
+  if (shouldForward && !wasForwarding) {
+    forwarder.addForwardingSubscriber();
+  } else if (wasForwarding && !shouldForward) {
+    forwarder.removeForwardingSubscriber();
+  }
+}
+
 void MoQForwarder::Subscriber::onPublishOk(const PublishOk& pubOk) {
   // Update subscriber range from PUBLISH_OK
   std::optional<AbsoluteLocation> end;
@@ -681,8 +691,7 @@ void MoQForwarder::Subscriber::onPublishOk(const PublishOk& pubOk) {
   range =
       toSubscribeRange(pubOk.start, end, pubOk.locType, forwarder.largest());
 
-  // Update forward flag
-  shouldForward = pubOk.forward;
+  updateForwardState(pubOk.forward);
 
   // Handle NEW_GROUP_REQUEST forwarding if present
   forwarder.tryProcessNewGroupRequest(pubOk.params);
@@ -719,16 +728,9 @@ MoQForwarder::Subscriber::requestUpdate(RequestUpdate requestUpdate) {
     range.end = newEnd;
   }
 
-  auto wasForwarding = shouldForward;
   // Only update forward state if explicitly provided (per draft 15+)
   if (requestUpdate.forward.has_value()) {
-    shouldForward = *requestUpdate.forward;
-  }
-
-  if (shouldForward && !wasForwarding) {
-    forwarder.addForwardingSubscriber();
-  } else if (wasForwarding && !shouldForward) {
-    forwarder.removeForwardingSubscriber();
+    updateForwardState(*requestUpdate.forward);
   }
 
   // Only update new group request if provided

--- a/moxygen/relay/MoQForwarder.h
+++ b/moxygen/relay/MoQForwarder.h
@@ -147,6 +147,12 @@ class MoQForwarder : public TrackConsumer {
     bool shouldForward;
     bool pinned{false};
     bool receivedPublishDone_{false};
+
+   private:
+    // Updates shouldForward and keeps forwardingSubscribers_ in sync,
+    // firing forwardChanged when the count crosses zero.  Shared by
+    // onPublishOk and requestUpdate.
+    void updateForwardState(bool newForward);
   };
 
   [[nodiscard]] bool empty() const {

--- a/moxygen/relay/test/MoQRelayTest.cpp
+++ b/moxygen/relay/test/MoQRelayTest.cpp
@@ -2935,4 +2935,70 @@ TEST_F(MoQRelayTest, RemoveForwardOnlySubscriberWithPublishDone) {
   EXPECT_TRUE(forwarder->empty());
 }
 
+// onPublishOk must update forwardingSubscribers_ (not just shouldForward) so
+// that forwardChanged fires and the publisher receives a corrective
+// REQUEST_UPDATE when the peer says fwd=false.
+TEST_F(MoQRelayTest, OnPublishOkUpdatesForwardingCount) {
+  auto session = createMockSession();
+  auto forwarder =
+      std::make_shared<MoQForwarder>(kTestTrackName, AbsoluteLocation{0, 0});
+
+  struct ForwardCallback : MoQForwarder::Callback {
+    void onEmpty(MoQForwarder*) override {}
+    void forwardChanged(MoQForwarder* f) override {
+      calls.push_back(f->numForwardingSubscribers());
+    }
+    std::vector<uint64_t> calls;
+  };
+  auto cb = std::make_shared<ForwardCallback>();
+  forwarder->setCallback(cb);
+
+  // Adding a forwarding subscriber fires forwardChanged (0->1).
+  auto subscriber = forwarder->addSubscriber(session, /*forward=*/true);
+  ASSERT_NE(subscriber, nullptr);
+  EXPECT_EQ(forwarder->numForwardingSubscribers(), 1u);
+  ASSERT_EQ(cb->calls.size(), 1u);
+  EXPECT_EQ(cb->calls[0], 1u);
+  cb->calls.clear();
+
+  // onPublishOk(fwd=false) must decrement the count and fire forwardChanged.
+  PublishOk pubOkFalse{
+      RequestID(0),
+      /*forward=*/false,
+      0,
+      GroupOrder::OldestFirst,
+      LocationType::AbsoluteStart,
+      AbsoluteLocation{0, 0},
+      std::nullopt,
+      TrackRequestParameters(FrameType::PUBLISH_OK)};
+  subscriber->onPublishOk(pubOkFalse);
+
+  EXPECT_FALSE(subscriber->shouldForward);
+  EXPECT_EQ(forwarder->numForwardingSubscribers(), 0u)
+      << "forwardingSubscribers_ must be decremented by onPublishOk(fwd=false)";
+  ASSERT_EQ(cb->calls.size(), 1u)
+      << "forwardChanged must fire when count drops to 0";
+  EXPECT_EQ(cb->calls[0], 0u);
+  cb->calls.clear();
+
+  // onPublishOk(fwd=true) must increment and fire forwardChanged again.
+  PublishOk pubOkTrue{
+      RequestID(0),
+      /*forward=*/true,
+      0,
+      GroupOrder::OldestFirst,
+      LocationType::AbsoluteStart,
+      AbsoluteLocation{0, 0},
+      std::nullopt,
+      TrackRequestParameters(FrameType::PUBLISH_OK)};
+  subscriber->onPublishOk(pubOkTrue);
+
+  EXPECT_TRUE(subscriber->shouldForward);
+  EXPECT_EQ(forwarder->numForwardingSubscribers(), 1u)
+      << "forwardingSubscribers_ must be incremented by onPublishOk(fwd=true)";
+  ASSERT_EQ(cb->calls.size(), 1u)
+      << "forwardChanged must fire when count rises to 1";
+  EXPECT_EQ(cb->calls[0], 1u);
+}
+
 } // namespace moxygen::test


### PR DESCRIPTION
Previously onPublishOk set shouldForward from the PUBLISH_OK forward flag but never called addForwardingSubscriber/removeForwardingSubscriber, leaving forwardingSubscribers_ stale. This meant forwardChanged never fired and no corrective REQUEST_UPDATE fwd=0 was sent to the publisher when the relay replied with forward=false.

Extracted updateForwardState(bool) helper — shared by both onPublishOk and requestUpdate — that atomically updates shouldForward and keeps forwardingSubscribers_ in sync, firing forwardChanged when the count crosses zero.

Added OnPublishOkUpdatesForwardingCount test to MoQRelayTest.

Upstream PR: https://github.com/facebookexperimental/moxygen/pull/146

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/149)
<!-- Reviewable:end -->
