### PR TITLE
ci: re-enable bookworm-arm64 publish job

### DIFF
--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -143,12 +143,11 @@ jobs:
             container: debian:bookworm
             cache_opts: "-v /home/github-runner/.cache/moxygen-publish-bookworm-amd64:/cache"
 
-          # bookworm-arm64 disabled — no current consumers
-          # - name: bookworm-arm64
-          #   runner: ubuntu-22.04-arm
-          #   artifact: moxygen-bookworm-arm64.tar.gz
-          #   debug_artifact: moxygen-bookworm-arm64-dbg.tar.gz
-          #   container: debian:bookworm
+          - name: bookworm-arm64
+            runner: ubuntu-22.04-arm
+            artifact: moxygen-bookworm-arm64.tar.gz
+            debug_artifact: moxygen-bookworm-arm64-dbg.tar.gz
+            container: debian:bookworm
 
     name: publish (${{ matrix.name }})
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
I want to deploy moqx to raspberryPis, so this is needed and I see no harm in enabling it and continuously testing on arm64.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/151)
<!-- Reviewable:end -->
