### PR TITLE
fix: evict non-live groups from live tracks when over byte limit

### DIFF
--- a/moxygen/relay/MoQCache.cpp
+++ b/moxygen/relay/MoQCache.cpp
@@ -289,7 +289,8 @@ MoQCache::CacheTrack::updateLargest(AbsoluteLocation current, bool eot) {
 
 MoQCache::CacheGroup& MoQCache::CacheTrack::getOrCreateGroup(
     uint64_t groupID,
-    MoQCache* cache) {
+    MoQCache* cache,
+    const FullTrackName* ftn) {
   auto it = groups.find(groupID);
   if (it == groups.end()) {
     // New group - try to evict old groups if needed
@@ -298,8 +299,8 @@ MoQCache::CacheGroup& MoQCache::CacheTrack::getOrCreateGroup(
     }
     it = groups.emplace(groupID, std::make_shared<CacheGroup>()).first;
     // New group starts in LRU (evictable)
-    if (cache) {
-      cache->addGroupToLRU(groupID, *it->second, *this);
+    if (cache && ftn) {
+      cache->addGroupToLRU(*ftn, groupID, *it->second, *this);
     }
   }
   return *it->second;
@@ -411,7 +412,8 @@ class MoQCache::SubgroupWriteback : public SubgroupConsumer {
       std::shared_ptr<SubgroupConsumer> consumer,
       std::shared_ptr<CacheTrack> cacheTrackPtr,
       std::shared_ptr<CacheGroup> cacheGroupPtr,
-      MoQCache& cache)
+      MoQCache& cache,
+      FullTrackName ftn)
       : group_(group),
         subgroup_(subgroup),
         consumer_(std::move(consumer)),
@@ -419,7 +421,8 @@ class MoQCache::SubgroupWriteback : public SubgroupConsumer {
         cacheTrack_(*cacheTrackPtr_),
         cacheGroupPtr_(std::move(cacheGroupPtr)),
         cacheGroup_(*cacheGroupPtr_),
-        cache_(cache) {
+        cache_(cache),
+        ftn_(std::move(ftn)) {
     cache_.removeGroupFromLRU(cacheGroup_, cacheTrack_);
   }
   SubgroupWriteback() = delete;
@@ -431,7 +434,7 @@ class MoQCache::SubgroupWriteback : public SubgroupConsumer {
   ~SubgroupWriteback() override {
     // TODO: If the publisher writes many groups concurrently, all are pinned
     // and none can be evicted, potentially using a lot of memory.
-    cache_.addGroupToLRU(group_, cacheGroup_, cacheTrack_);
+    cache_.addGroupToLRU(ftn_, group_, cacheGroup_, cacheTrack_);
   }
 
   folly::Expected<folly::Unit, MoQPublishError> object(
@@ -620,6 +623,7 @@ class MoQCache::SubgroupWriteback : public SubgroupConsumer {
   std::shared_ptr<CacheGroup> cacheGroupPtr_; // Prevent UAF if cache cleared
   CacheGroup& cacheGroup_;
   MoQCache& cache_;
+  FullTrackName ftn_;
   uint64_t currentObject_{0};
   uint64_t currentLength_{0};
 };
@@ -669,14 +673,15 @@ class MoQCache::SubscribeWriteback : public TrackConsumer {
     // TODO: Handle containsLastInGroup parameter when caching
     auto res = consumer_->beginSubgroup(groupID, subgroupID, priority);
     if (res.hasValue() && !track_.evicted) {
-      track_.getOrCreateGroup(groupID, &cache_);
+      track_.getOrCreateGroup(groupID, &cache_, &ftn_);
       return std::make_shared<SubgroupWriteback>(
           groupID,
           subgroupID,
           std::move(res.value()),
           trackPtr_,
           trackPtr_->groups[groupID],
-          cache_);
+          cache_,
+          ftn_);
     } else {
       return res;
     }
@@ -701,7 +706,7 @@ class MoQCache::SubscribeWriteback : public TrackConsumer {
       return res;
     }
     auto cacheRes = cache_.cacheObjectAndUpdateBytes(
-        track_.getOrCreateGroup(header.group, &cache_),
+        track_.getOrCreateGroup(header.group, &cache_, &ftn_),
         track_,
         header.subgroup,
         header.id,
@@ -736,7 +741,7 @@ class MoQCache::SubscribeWriteback : public TrackConsumer {
       return res;
     }
     auto cacheRes = cache_.cacheObjectAndUpdateBytes(
-        track_.getOrCreateGroup(header.group, &cache_),
+        track_.getOrCreateGroup(header.group, &cache_, &ftn_),
         track_,
         header.subgroup,
         header.id,
@@ -1862,15 +1867,18 @@ void MoQCache::onTrackBecameEvictable(const FullTrackName& ftn) {
 // ============================================================================
 
 void MoQCache::addGroupToLRU(
+    const FullTrackName& ftn,
     uint64_t groupID,
     CacheGroup& group,
     CacheTrack& track) {
   if (group.lruIter_.hasValue()) {
-    // Already in LRU
+    // Already in per-track LRU
     return;
   }
   track.groupLRU.push_front(groupID);
   group.lruIter_ = track.groupLRU.begin();
+  globalGroupLRU_.push_front({ftn, groupID});
+  group.globalLruIter_ = globalGroupLRU_.begin();
   XLOG(DBG2) << "Added group " << groupID << " to LRU";
 }
 
@@ -1881,6 +1889,10 @@ void MoQCache::removeGroupFromLRU(CacheGroup& group, CacheTrack& track) {
   }
   track.groupLRU.erase(*group.lruIter_);
   group.lruIter_.reset();
+  if (group.globalLruIter_.hasValue()) {
+    globalGroupLRU_.erase(*group.globalLruIter_);
+    group.globalLruIter_.reset();
+  }
   XLOG(DBG2) << "Removed group from LRU";
 }
 
@@ -1932,10 +1944,10 @@ size_t MoQCache::evictTrack(const FullTrackName& ftn) {
     trackLRU_.erase(*track.lruIter_);
   }
 
-  // Subtract bytes for all groups in the track
-  for (auto& [gid, group] : track.groups) {
-    XCHECK_GE(totalCachedBytes_, group->totalBytes);
-    totalCachedBytes_ -= group->totalBytes;
+  // Evict each group to clean up per-track and global LRUs and byte accounting.
+  // evictGroup() erases from track.groups, so re-read begin() each iteration.
+  while (!track.groups.empty()) {
+    evictGroup(track, track.groups.begin()->first);
   }
 
   // Remove from cache
@@ -1999,9 +2011,12 @@ void MoQCache::evictGroup(CacheTrack& track, uint64_t groupID) {
   }
 
   auto& group = *it->second;
-  // Remove from LRU if present
+  // Remove from per-track and global LRUs if present
   if (group.lruIter_.hasValue()) {
     track.groupLRU.erase(*group.lruIter_);
+  }
+  if (group.globalLruIter_.hasValue()) {
+    globalGroupLRU_.erase(*group.globalLruIter_);
   }
 
   // Subtract group's bytes from the cache total
@@ -2021,42 +2036,36 @@ bool MoQCache::evictForByteLimitIfNeeded() {
   size_t targetBytes = minEvictionBytes_ < maxCachedBytes_
       ? maxCachedBytes_ - minEvictionBytes_
       : 0;
-  while (totalCachedBytes_ > targetBytes && !trackLRU_.empty()) {
-    const FullTrackName& oldestTrackName = trackLRU_.back();
-    auto it = cache_.find(oldestTrackName);
-    if (it == cache_.end()) {
-      trackLRU_.pop_back();
+
+  // Evict oldest evictable groups globally (covers both live and non-live
+  // tracks). After evicting a group from a non-live (fully evictable) track
+  // that becomes empty, also evict the empty track shell.
+  while (totalCachedBytes_ > targetBytes && !globalGroupLRU_.empty()) {
+    const auto& [ftn, groupID] = globalGroupLRU_.back();
+    auto trackIt = cache_.find(ftn);
+    if (trackIt == cache_.end()) {
+      // Stale entry — should not happen since evictTrack now calls evictGroup
+      // for every group, but guard defensively against future code paths.
+      XLOG(DFATAL) << "globalGroupLRU_ has stale entry for evicted track: "
+                   << ftn;
+      globalGroupLRU_.pop_back();
       continue;
     }
-    auto& track = *it->second;
-    if (!track.groupLRU.empty()) {
-      // Evict oldest evictable group from the LRU track
-      uint64_t oldestGroupID = track.groupLRU.back();
-      XLOG(DBG1) << "Evicting group " << oldestGroupID << " from track "
-                 << oldestTrackName
-                 << " for byte limit (bytes: " << totalCachedBytes_
-                 << " > limit: " << maxCachedBytes_ << ")";
-      evictGroup(track, oldestGroupID);
-      // If track now has no groups, evict the empty shell
-      if (track.groups.empty()) {
-        evictTrack(oldestTrackName);
-      }
-    } else if (track.groups.empty()) {
-      // Empty shell track — safe to evict
-      XLOG(DBG1) << "Evicting empty track for byte limit: " << oldestTrackName;
-      evictTrack(oldestTrackName);
-    } else {
-      // Should be unreachable: if a track is in trackLRU_ it is evictable
-      // (canEvict() == true), which means no active fetches or subscribes,
-      // so all its groups should be in groupLRU.
-      XLOG(DFATAL) << "LRU track " << oldestTrackName
-                   << " has groups but empty groupLRU";
-      break;
+    auto& track = *trackIt->second;
+    XLOG(DBG1) << "Evicting group " << groupID << " from track " << ftn
+               << " for byte limit (bytes: " << totalCachedBytes_
+               << " > limit: " << maxCachedBytes_ << ")";
+    // evictGroup() erases the globalGroupLRU_ node, invalidating ftn/groupID.
+    // Use trackIt->first for any post-eviction access to the track name.
+    evictGroup(track, groupID);
+    if (track.groups.empty() && track.canEvict()) {
+      evictTrack(trackIt->first);
     }
   }
+
   if (totalCachedBytes_ > maxCachedBytes_) {
-    XLOG(DBG1) << "Cannot reduce cache below byte limit, all tracks have "
-                  "active operations. Bytes: "
+    XLOG(DBG1) << "Cannot reduce cache below byte limit, all evictable "
+                  "groups are actively being written. Bytes: "
                << totalCachedBytes_ << ", limit: " << maxCachedBytes_;
     return false;
   }

--- a/moxygen/relay/MoQCache.h
+++ b/moxygen/relay/MoQCache.h
@@ -222,8 +222,13 @@ class MoQCache {
     std::optional<uint64_t> seenPriorGroupIdGap;
     // Total payload bytes across all objects in this group
     size_t totalBytes{0};
-    // LRU iterator - present if group is evictable (not in active fetch)
+    // Per-track LRU iterator - present if group is evictable (not in active
+    // SubgroupWriteback). Used by evictOldestGroupsIfNeeded().
     folly::Optional<std::list<uint64_t>::iterator> lruIter_;
+    // Global LRU iterator - present if group is evictable.
+    // Used by evictForByteLimitIfNeeded().
+    folly::Optional<std::list<std::pair<FullTrackName, uint64_t>>::iterator>
+        globalLruIter_;
 
     folly::Expected<folly::Unit, MoQPublishError> cacheObject(
         uint64_t subgroup,
@@ -268,7 +273,10 @@ class MoQCache {
     folly::Expected<folly::Unit, MoQPublishError> updateLargest(
         AbsoluteLocation current,
         bool endOfTrack = false);
-    CacheGroup& getOrCreateGroup(uint64_t groupID, MoQCache* cache = nullptr);
+    CacheGroup& getOrCreateGroup(
+        uint64_t groupID,
+        MoQCache* cache = nullptr,
+        const FullTrackName* ftn = nullptr);
 
     // Process Prior Group ID Gap and Prior Object ID Gap extensions
     // and cache the missing groups/objects accordingly
@@ -327,6 +335,9 @@ class MoQCache {
 
   // LRU list of evictable tracks (oldest at back)
   std::list<FullTrackName> trackLRU_;
+  // Global LRU of evictable groups across all tracks (oldest at back).
+  // Entry: {FullTrackName, groupID}. Used by evictForByteLimitIfNeeded().
+  std::list<std::pair<FullTrackName, uint64_t>> globalGroupLRU_;
 
   // Cache size limits
   size_t maxCachedTracks_;
@@ -372,7 +383,11 @@ class MoQCache {
   void onTrackBecameEvictable(const FullTrackName& ftn);
 
   // Group LRU management helpers
-  void addGroupToLRU(uint64_t groupID, CacheGroup& group, CacheTrack& track);
+  void addGroupToLRU(
+      const FullTrackName& ftn,
+      uint64_t groupID,
+      CacheGroup& group,
+      CacheTrack& track);
   void removeGroupFromLRU(CacheGroup& group, CacheTrack& track);
   bool canEvictGroup(uint64_t groupID, CacheTrack& track);
 

--- a/moxygen/relay/test/MoQCacheTests.cpp
+++ b/moxygen/relay/test/MoQCacheTests.cpp
@@ -2590,20 +2590,25 @@ CO_TEST_F(MoQCacheTest, TestByteLimitEvictsLRUGroup) {
 }
 
 CO_TEST_F(MoQCacheTest, TestByteLimitNoEvictLiveTrack) {
-  // Live track (active subscribe) must not be evicted even when over limit
+  // The live track's shell must not be evicted even when over limit.
+  // Groups are evicted in global LRU order (oldest first); the non-live
+  // track is written first so its group is evicted before the live track's.
   FullTrackName track1{TrackNamespace{{"ns"}}, "track1"};
   FullTrackName track2{TrackNamespace{{"ns"}}, "track2"};
 
-  auto sub1 = cache_.getSubscribeWriteback(track1, trackConsumer_);
-  sub1->datagram(ObjectHeader(0, 0, 0, 0, 100), makeBuf(100));
-  // sub1 stays alive — track1 is live and non-evictable
-
+  // track2 written first → its group is oldest in globalGroupLRU_
   auto sub2 = cache_.getSubscribeWriteback(track2, trackConsumer_);
   sub2->datagram(ObjectHeader(0, 0, 0, 0, 100), makeBuf(100));
   sub2.reset(); // track2 is evictable
 
-  // Both tracks have 100 bytes each = 200 bytes total
-  // Limit to 150: track2 should be evicted, track1 (live) must survive
+  // track1 written second → its group is newer in globalGroupLRU_
+  auto sub1 = cache_.getSubscribeWriteback(track1, trackConsumer_);
+  sub1->datagram(ObjectHeader(0, 0, 0, 0, 100), makeBuf(100));
+  // sub1 stays alive — track1 is live
+
+  // Both tracks have 100 bytes each = 200 bytes total.
+  // Limit to 150: track2's group (oldest) is evicted first, leaving 100b.
+  // track2 shell is then evicted (empty + canEvict()), track1 survives.
   cache_.setMaxCachedBytes(150);
 
   EXPECT_TRUE(cache_.hasTrack(track1));
@@ -2684,6 +2689,145 @@ CO_TEST_F(MoQCacheTest, TestMinEvictionBytesLowWatermark) {
   EXPECT_TRUE(cache_.hasCachedObject(kTestTrackName, {2, 0}));
   EXPECT_TRUE(cache_.hasCachedObject(kTestTrackName, {3, 0}));
   EXPECT_TRUE(cache_.hasCachedObject(kTestTrackName, {4, 0}));
+  co_return;
+}
+
+CO_TEST_F(MoQCacheTest, TestByteLimitEvictsGroupsFromLiveTrack) {
+  // Single live track with 3 groups × 100b = 300b. trackLRU_ is empty because
+  // the track is live. The global group LRU must be used to shed old groups.
+  auto writeback = cache_.getSubscribeWriteback(kTestTrackName, trackConsumer_);
+  writeback->datagram(ObjectHeader(0, 0, 0, 0, 100), makeBuf(100));
+  writeback->datagram(ObjectHeader(1, 0, 0, 0, 100), makeBuf(100));
+  writeback->datagram(ObjectHeader(2, 0, 0, 0, 100), makeBuf(100));
+  // writeback stays alive — track is live
+
+  EXPECT_TRUE(cache_.hasCachedObject(kTestTrackName, {0, 0}));
+  EXPECT_TRUE(cache_.hasCachedObject(kTestTrackName, {1, 0}));
+  EXPECT_TRUE(cache_.hasCachedObject(kTestTrackName, {2, 0}));
+
+  // Limit to 250b: oldest group (0) evicted, 200b remaining ≤ 250b.
+  cache_.setMaxCachedBytes(250);
+
+  EXPECT_FALSE(cache_.hasCachedObject(kTestTrackName, {0, 0}));
+  EXPECT_TRUE(cache_.hasCachedObject(kTestTrackName, {1, 0}));
+  EXPECT_TRUE(cache_.hasCachedObject(kTestTrackName, {2, 0}));
+  // Track shell must survive — live writeback still needs it.
+  EXPECT_TRUE(cache_.hasTrack(kTestTrackName));
+  EXPECT_EQ(cache_.totalCachedBytes(), 200u);
+  co_return;
+}
+
+CO_TEST_F(MoQCacheTest, TestByteLimitLiveTrackMultipleGroupsEvicted) {
+  // Live track, 5 groups × 100b = 500b. minEvictionBytes=150 → targetBytes=300.
+  // Second pass must evict groups 0 and 1 to reach 300b.
+  cache_.setMinEvictionBytes(150);
+
+  auto writeback = cache_.getSubscribeWriteback(kTestTrackName, trackConsumer_);
+  writeback->datagram(ObjectHeader(0, 0, 0, 0, 100), makeBuf(100));
+  writeback->datagram(ObjectHeader(1, 0, 0, 0, 100), makeBuf(100));
+  writeback->datagram(ObjectHeader(2, 0, 0, 0, 100), makeBuf(100));
+  writeback->datagram(ObjectHeader(3, 0, 0, 0, 100), makeBuf(100));
+  writeback->datagram(ObjectHeader(4, 0, 0, 0, 100), makeBuf(100));
+  // writeback alive — track stays live
+
+  cache_.setMaxCachedBytes(450);
+
+  EXPECT_FALSE(cache_.hasCachedObject(kTestTrackName, {0, 0}));
+  EXPECT_FALSE(cache_.hasCachedObject(kTestTrackName, {1, 0}));
+  EXPECT_TRUE(cache_.hasCachedObject(kTestTrackName, {2, 0}));
+  EXPECT_TRUE(cache_.hasCachedObject(kTestTrackName, {3, 0}));
+  EXPECT_TRUE(cache_.hasCachedObject(kTestTrackName, {4, 0}));
+  EXPECT_TRUE(cache_.hasTrack(kTestTrackName));
+  EXPECT_EQ(cache_.totalCachedBytes(), 300u);
+  co_return;
+}
+
+CO_TEST_F(MoQCacheTest, TestByteLimitLiveTrackWithActiveSubgroupNotEvicted) {
+  // Group 0 is complete (in globalGroupLRU_, evictable).
+  // Group 1 has an active SubgroupWriteback (NOT in globalGroupLRU_, must not
+  // be evicted). Limit 150b: only group 0 can be evicted → 100b remaining.
+  auto writeback = cache_.getSubscribeWriteback(kTestTrackName, trackConsumer_);
+  writeback->datagram(ObjectHeader(0, 0, 0, 0, 100), makeBuf(100));
+
+  // Open a SubgroupWriteback for group 1 — removes group 1 from globalGroupLRU_.
+  auto subRes = writeback->beginSubgroup(1, 0, 0);
+  EXPECT_TRUE(subRes.hasValue());
+  auto subConsumer = std::move(subRes.value());
+  // Write a complete object so hasCachedObject can find it.
+  EXPECT_TRUE(subConsumer->object(0, makeBuf(100), {}, false).hasValue());
+  // subConsumer still alive → group 1 NOT in globalGroupLRU_
+
+  cache_.setMaxCachedBytes(150);
+
+  // Group 0 (in globalGroupLRU_) must be evicted.
+  EXPECT_FALSE(cache_.hasCachedObject(kTestTrackName, {0, 0}));
+  // Group 1 is actively being written — must survive.
+  EXPECT_TRUE(cache_.hasCachedObject(kTestTrackName, {1, 0}));
+  EXPECT_TRUE(cache_.hasTrack(kTestTrackName));
+  EXPECT_EQ(cache_.totalCachedBytes(), 100u);
+  co_return;
+}
+
+CO_TEST_F(MoQCacheTest, TestByteLimitEvictsAcrossLiveAndNonLiveTracks) {
+  // One non-live track (written first, group is older) and one live track.
+  // Byte limit forces eviction: the non-live track's group is evicted first
+  // (globally oldest), its empty shell is cleaned up, live track survives.
+  FullTrackName track1{TrackNamespace{{"ns"}}, "track1"};
+  FullTrackName track2{TrackNamespace{{"ns"}}, "track2"};
+
+  // track1 non-live, written first → its group is oldest in globalGroupLRU_
+  auto sub1 = cache_.getSubscribeWriteback(track1, trackConsumer_);
+  sub1->datagram(ObjectHeader(0, 0, 0, 0, 100), makeBuf(100));
+  sub1.reset();
+
+  // track2 live, written second → its group is newer
+  auto sub2 = cache_.getSubscribeWriteback(track2, trackConsumer_);
+  sub2->datagram(ObjectHeader(0, 0, 0, 0, 100), makeBuf(100));
+  // sub2 alive — track2 is live
+
+  // 200b total, limit 150b: evict track1's group (oldest) → 100b ≤ 150b.
+  // track1 is empty + canEvict() → evict shell too.
+  cache_.setMaxCachedBytes(150);
+
+  EXPECT_FALSE(cache_.hasTrack(track1));
+  EXPECT_TRUE(cache_.hasTrack(track2));
+  EXPECT_TRUE(cache_.hasCachedObject(track2, {0, 0}));
+  EXPECT_EQ(cache_.totalCachedBytes(), 100u);
+  co_return;
+}
+
+CO_TEST_F(MoQCacheTest, TestTrackEvictionCleansGlobalGroupLRU) {
+  // Regression: evictTrack() must remove all groups from globalGroupLRU_ so
+  // that a subsequent byte-limit eviction does not encounter stale entries.
+  //
+  // Setup: maxCachedTracks=1. Write track1 (100b) then release it so it is
+  // evictable. Writing track2 triggers evictOldestTrackIfNeeded which evicts
+  // track1 — including its group from globalGroupLRU_. Then tighten the byte
+  // limit to force eviction of track2's group and verify counts stay correct.
+  FullTrackName track1{TrackNamespace{{"ns"}}, "track1"};
+  FullTrackName track2{TrackNamespace{{"ns"}}, "track2"};
+
+  cache_.setMaxCachedTracks(1);
+
+  auto sub1 = cache_.getSubscribeWriteback(track1, trackConsumer_);
+  sub1->datagram(ObjectHeader(0, 0, 0, 0, 100), makeBuf(100));
+  sub1.reset(); // track1 evictable; its group is in globalGroupLRU_
+
+  // Writing track2 exceeds the track limit and evicts track1.
+  auto sub2 = cache_.getSubscribeWriteback(track2, trackConsumer_);
+  sub2->datagram(ObjectHeader(0, 0, 0, 0, 100), makeBuf(100));
+
+  EXPECT_FALSE(cache_.hasTrack(track1));
+  EXPECT_TRUE(cache_.hasTrack(track2));
+  EXPECT_EQ(cache_.totalCachedBytes(), 100u);
+
+  // Now evict track2's group via byte limit. globalGroupLRU_ must only contain
+  // track2's group — no stale entry for track1.
+  sub2.reset(); // make track2 evictable so its shell can be cleaned up too
+  cache_.setMaxCachedBytes(50);
+
+  EXPECT_FALSE(cache_.hasTrack(track2));
+  EXPECT_EQ(cache_.totalCachedBytes(), 0u);
   co_return;
 }
 


### PR DESCRIPTION
Add a global group LRU (globalGroupLRU_) alongside the existing per-track groupLRU. evictForByteLimitIfNeeded() now iterates the global LRU, which includes evictable groups from both live and non-live tracks. This fixes the case where all tracks have active SubscribeWriteback/FetchWriteback and the cache could not shed bytes despite old completed groups being available for eviction.

Per-track groupLRU is retained for evictOldestGroupsIfNeeded() which needs to find the oldest group within a specific track for group-count limits. evictGroup() and evictTrack() maintain both LRUs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/153)
<!-- Reviewable:end -->
