### PR TITLE
ci: lift Linode -j caps after runner resize; route PR asan to Linode

### DIFF
--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -95,12 +95,11 @@ jobs:
             "${ASAN_FLAGS[@]}" "${EXTRA_FLAGS[@]}"
 
       - name: Build
-        # asan debug on the 16 GB Linode runner OOMs under -j$(nproc)
-        # during test compilation (cc1plus killed). Match the publish-job
-        # cap of -j6 to leave memory headroom.
+        # asan debug runs on the Linode self-hosted runner; leave 2 cores
+        # of headroom to avoid cc1plus OOM during test compilation.
         run: |
           if [ "${{ matrix.name }}" = "asan debug" ]; then
-            cmake --build _build -j6
+            cmake --build _build -j$(( $(getconf _NPROCESSORS_ONLN) - 2 ))
           else
             cmake --build _build -j$(getconf _NPROCESSORS_ONLN)
           fi
@@ -217,10 +216,10 @@ jobs:
             "${EXTRA_FLAGS[@]}"
 
       - name: Build
-        # Cap parallel jobs to avoid OOM during the link phase (publish
-        # build OOMed at -j8 on the 16 GB Linode runner during MoQTests
-        # link). -j6 keeps most throughput while leaving headroom.
-        run: cmake --build _build -j6
+        # Leave 2 cores of headroom for the Linode bookworm-amd64 publish
+        # job to avoid OOM during MoQTests link (was -j6 pre-resize).
+        # GitHub-hosted matrix entries (ubuntu/macos/arm) are also fine here.
+        run: cmake --build _build -j$(( $(getconf _NPROCESSORS_ONLN) - 2 ))
 
       - name: Install
         run: cmake --install _build

--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Fix workspace ownership (self-hosted)
         if: ${{ contains(toJSON(matrix.runner), 'linode') }}
         run: |
-          sudo rm -rf "$GITHUB_WORKSPACE/_build" "$GITHUB_WORKSPACE/install"
+          sudo rm -rf "$GITHUB_WORKSPACE/_build" "$GITHUB_WORKSPACE/_install"
           sudo chown -R $(id -u):$(id -g) "$GITHUB_WORKSPACE"
 
       - uses: actions/checkout@v4

--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -95,8 +95,7 @@ jobs:
             "${ASAN_FLAGS[@]}" "${EXTRA_FLAGS[@]}"
 
       - name: Build
-        # asan debug runs on the Linode self-hosted runner; leave 2 cores
-        # of headroom to avoid cc1plus OOM during test compilation.
+        # Linode (asan debug): -j(n-2) reserves 2 cores for co-resident workloads.
         run: |
           if [ "${{ matrix.name }}" = "asan debug" ]; then
             cmake --build _build -j$(( $(getconf _NPROCESSORS_ONLN) - 2 ))
@@ -216,9 +215,8 @@ jobs:
             "${EXTRA_FLAGS[@]}"
 
       - name: Build
-        # Leave 2 cores of headroom for the Linode bookworm-amd64 publish
-        # job to avoid OOM during MoQTests link (was -j6 pre-resize).
-        # GitHub-hosted matrix entries (ubuntu/macos/arm) are also fine here.
+        # -j(n-2): on Linode reserves cores for co-resident workloads;
+        # GitHub-hosted entries (ubuntu/macos/arm) tolerate it fine.
         run: cmake --build _build -j$(( $(getconf _NPROCESSORS_ONLN) - 2 ))
 
       - name: Install

--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -215,9 +215,13 @@ jobs:
             "${EXTRA_FLAGS[@]}"
 
       - name: Build
-        # -j(n-2): on Linode reserves cores for co-resident workloads;
-        # GitHub-hosted entries (ubuntu/macos/arm) tolerate it fine.
-        run: cmake --build _build -j$(( $(getconf _NPROCESSORS_ONLN) - 2 ))
+        # Linode: -j(n-2) reserves cores for co-resident workloads (e.g. relay).
+        run: |
+          if echo '${{ toJSON(matrix.runner) }}' | grep -q linode; then
+            cmake --build _build -j$(( $(getconf _NPROCESSORS_ONLN) - 2 ))
+          else
+            cmake --build _build -j$(getconf _NPROCESSORS_ONLN)
+          fi
 
       - name: Install
         run: cmake --install _build

--- a/.github/workflows/omoq-ci-pr.yml
+++ b/.github/workflows/omoq-ci-pr.yml
@@ -1,12 +1,9 @@
 name: ci pr
 
 # PR verification: build/test matrix.
-# Main push uses omoq-ci-main.yml which adds publish/release/notify.
-#
-# asan debug routes to the Linode self-hosted runner for non-fork PRs
-# (member branches, sync bot PRs) — same runner as ci-main, with cache reuse.
-# Fork PRs fall back to GitHub-hosted ubuntu, since self-hosted on fork PRs
-# needs per-run admin approval.
+# Main push uses omoq-ci-main.yml (adds publish/release/notify).
+# asan debug runs on the Linode self-hosted runner for same-repo PRs
+# (cache reuse, faster); fork PRs fall back to matrix.runner.
 
 on:
   pull_request:
@@ -36,16 +33,13 @@ jobs:
           - runner: macos-15
             name: macos
             cache_prefix: ci-ninja-macos-15
-          - runner: ubuntu-22.04   # fork-PR fallback; non-fork PRs use Linode (see runs-on)
+          - runner: ubuntu-22.04   # fork-PR fallback (same-repo PRs route to Linode)
             linode: true
             name: asan debug
             cache_prefix: ci-asan-ubuntu-22.04
     name: ${{ matrix.name }}
-    # Same-repo PRs can use the Linode self-hosted runner; cross-repo (fork)
-    # PRs fall back to matrix.runner since self-hosted on forks requires
-    # per-run admin approval. Note: head.repo.fork is NOT the right check —
-    # openmoq/moxygen is itself a fork of facebookexperimental/moxygen, so
-    # that flag is always true. Compare full_name to github.repository instead.
+    # head.repo.fork is the wrong check — openmoq/moxygen is itself a fork of
+    # upstream, so it's always true. Compare full_name to github.repository.
     runs-on: ${{ fromJSON(matrix.linode && github.event.pull_request.head.repo.full_name == github.repository && '["self-hosted","linode"]' || format('["{0}"]', matrix.runner)) }}
     env:
       USE_LINODE: ${{ (matrix.linode && github.event.pull_request.head.repo.full_name == github.repository) && 'true' || 'false' }}
@@ -89,8 +83,7 @@ jobs:
               -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address"
             )
           fi
-          # On Linode self-hosted: persist FetchContent outside workspace
-          # (namespaced per cache_prefix to avoid cross-build collisions).
+          # Linode: persist FetchContent under $HOME, namespaced per cache_prefix.
           if [ "$USE_LINODE" = "true" ]; then
             EXTRA_FLAGS+=(-DFETCHCONTENT_BASE_DIR="$HOME/.cache/moxygen-${{ matrix.cache_prefix }}/_deps")
           fi
@@ -103,8 +96,7 @@ jobs:
             "${ASAN_FLAGS[@]}" "${EXTRA_FLAGS[@]}"
 
       - name: Build
-        # On Linode (asan debug, non-fork PRs): leave 2 cores of headroom
-        # to avoid cc1plus OOM during test compilation. Elsewhere: full nproc.
+        # Linode: -j(n-2) reserves 2 cores for co-resident workloads (e.g. relay).
         run: |
           if [ "$USE_LINODE" = "true" ]; then
             cmake --build _build -j$(( $(getconf _NPROCESSORS_ONLN) - 2 ))

--- a/.github/workflows/omoq-ci-pr.yml
+++ b/.github/workflows/omoq-ci-pr.yml
@@ -2,6 +2,11 @@ name: ci pr
 
 # PR verification: build/test matrix.
 # Main push uses omoq-ci-main.yml which adds publish/release/notify.
+#
+# asan debug routes to the Linode self-hosted runner for non-fork PRs
+# (member branches, sync bot PRs) — same runner as ci-main, with cache reuse.
+# Fork PRs fall back to GitHub-hosted ubuntu, since self-hosted on fork PRs
+# needs per-run admin approval.
 
 on:
   pull_request:
@@ -25,24 +30,35 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - runner: ubuntu-22.04
             name: linux
             cache_prefix: ci-ninja-ubuntu-22.04
-          - os: macos-15
+          - runner: macos-15
             name: macos
             cache_prefix: ci-ninja-macos-15
-          - os: ubuntu-22.04
+          - runner: ubuntu-22.04   # fork-PR fallback; non-fork PRs use Linode (see runs-on)
+            linode: true
             name: asan debug
             cache_prefix: ci-asan-ubuntu-22.04
     name: ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ (matrix.linode && !github.event.pull_request.head.repo.fork) && fromJSON('["self-hosted","linode"]') || matrix.runner }}
+    env:
+      USE_LINODE: ${{ (matrix.linode && !github.event.pull_request.head.repo.fork) && 'true' || 'false' }}
     steps:
+      - name: Fix workspace ownership (self-hosted)
+        if: env.USE_LINODE == 'true'
+        run: |
+          sudo rm -rf "$GITHUB_WORKSPACE/_build" "$GITHUB_WORKSPACE/_install"
+          sudo chown -R $(id -u):$(id -g) "$GITHUB_WORKSPACE"
+
       - uses: actions/checkout@v4
 
       - name: Install system dependencies
+        if: env.USE_LINODE != 'true'
         run: bash standalone/install-system-deps.sh
 
       - name: Cache FetchContent downloads
+        if: env.USE_LINODE != 'true'
         uses: actions/cache@v4
         with:
           path: _build/_deps
@@ -51,6 +67,7 @@ jobs:
             ${{ matrix.cache_prefix }}-deps-
 
       - name: Set up ccache
+        if: env.USE_LINODE != 'true'
         uses: hendrikmuhs/ccache-action@v1
         with:
           key: ${{ matrix.cache_prefix }}
@@ -59,6 +76,7 @@ jobs:
       - name: Configure
         run: |
           ASAN_FLAGS=()
+          EXTRA_FLAGS=()
           if [ "${{ matrix.name }}" = "asan debug" ]; then
             ASAN_FLAGS=(
               -DCMAKE_CXX_FLAGS="-fsanitize=address -fno-omit-frame-pointer"
@@ -66,16 +84,28 @@ jobs:
               -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address"
             )
           fi
+          # On Linode self-hosted: persist FetchContent outside workspace
+          # (namespaced per cache_prefix to avoid cross-build collisions).
+          if [ "$USE_LINODE" = "true" ]; then
+            EXTRA_FLAGS+=(-DFETCHCONTENT_BASE_DIR="$HOME/.cache/moxygen-${{ matrix.cache_prefix }}/_deps")
+          fi
           cmake -B _build -S standalone -G Ninja \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DBUILD_TESTING=ON \
             -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/_install \
-            "${ASAN_FLAGS[@]}"
+            "${ASAN_FLAGS[@]}" "${EXTRA_FLAGS[@]}"
 
       - name: Build
-        run: cmake --build _build -j$(getconf _NPROCESSORS_ONLN)
+        # On Linode (asan debug, non-fork PRs): leave 2 cores of headroom
+        # to avoid cc1plus OOM during test compilation. Elsewhere: full nproc.
+        run: |
+          if [ "$USE_LINODE" = "true" ]; then
+            cmake --build _build -j$(( $(getconf _NPROCESSORS_ONLN) - 2 ))
+          else
+            cmake --build _build -j$(getconf _NPROCESSORS_ONLN)
+          fi
 
       - name: Test
         env:

--- a/.github/workflows/omoq-ci-pr.yml
+++ b/.github/workflows/omoq-ci-pr.yml
@@ -41,10 +41,20 @@ jobs:
             name: asan debug
             cache_prefix: ci-asan-ubuntu-22.04
     name: ${{ matrix.name }}
-    runs-on: ${{ (matrix.linode && !github.event.pull_request.head.repo.fork) && fromJSON('["self-hosted","linode"]') || matrix.runner }}
+    runs-on: ${{ fromJSON(matrix.linode && !github.event.pull_request.head.repo.fork && '["self-hosted","linode"]' || format('["{0}"]', matrix.runner)) }}
     env:
       USE_LINODE: ${{ (matrix.linode && !github.event.pull_request.head.repo.fork) && 'true' || 'false' }}
     steps:
+      - name: Debug runner selection
+        run: |
+          echo "matrix.name=${{ matrix.name }}"
+          echo "matrix.runner=${{ matrix.runner }}"
+          echo "matrix.linode=${{ matrix.linode }}"
+          echo "head.repo.fork=${{ github.event.pull_request.head.repo.fork }}"
+          echo "USE_LINODE=$USE_LINODE"
+          echo "runner.name=$RUNNER_NAME"
+          echo "runner.os=$RUNNER_OS"
+
       - name: Fix workspace ownership (self-hosted)
         if: env.USE_LINODE == 'true'
         run: |

--- a/.github/workflows/omoq-ci-pr.yml
+++ b/.github/workflows/omoq-ci-pr.yml
@@ -75,15 +75,7 @@ jobs:
             "${ASAN_FLAGS[@]}"
 
       - name: Build
-        # asan debug on the 16 GB Linode runner OOMs under -j$(nproc)
-        # during test compilation (cc1plus killed). Match the publish-job
-        # cap of -j6 to leave memory headroom.
-        run: |
-          if [ "${{ matrix.name }}" = "asan debug" ]; then
-            cmake --build _build -j6
-          else
-            cmake --build _build -j$(getconf _NPROCESSORS_ONLN)
-          fi
+        run: cmake --build _build -j$(getconf _NPROCESSORS_ONLN)
 
       - name: Test
         env:

--- a/.github/workflows/omoq-ci-pr.yml
+++ b/.github/workflows/omoq-ci-pr.yml
@@ -41,20 +41,15 @@ jobs:
             name: asan debug
             cache_prefix: ci-asan-ubuntu-22.04
     name: ${{ matrix.name }}
-    runs-on: ${{ fromJSON(matrix.linode && !github.event.pull_request.head.repo.fork && '["self-hosted","linode"]' || format('["{0}"]', matrix.runner)) }}
+    # Same-repo PRs can use the Linode self-hosted runner; cross-repo (fork)
+    # PRs fall back to matrix.runner since self-hosted on forks requires
+    # per-run admin approval. Note: head.repo.fork is NOT the right check —
+    # openmoq/moxygen is itself a fork of facebookexperimental/moxygen, so
+    # that flag is always true. Compare full_name to github.repository instead.
+    runs-on: ${{ fromJSON(matrix.linode && github.event.pull_request.head.repo.full_name == github.repository && '["self-hosted","linode"]' || format('["{0}"]', matrix.runner)) }}
     env:
-      USE_LINODE: ${{ (matrix.linode && !github.event.pull_request.head.repo.fork) && 'true' || 'false' }}
+      USE_LINODE: ${{ (matrix.linode && github.event.pull_request.head.repo.full_name == github.repository) && 'true' || 'false' }}
     steps:
-      - name: Debug runner selection
-        run: |
-          echo "matrix.name=${{ matrix.name }}"
-          echo "matrix.runner=${{ matrix.runner }}"
-          echo "matrix.linode=${{ matrix.linode }}"
-          echo "head.repo.fork=${{ github.event.pull_request.head.repo.fork }}"
-          echo "USE_LINODE=$USE_LINODE"
-          echo "runner.name=$RUNNER_NAME"
-          echo "runner.os=$RUNNER_OS"
-
       - name: Fix workspace ownership (self-hosted)
         if: env.USE_LINODE == 'true'
         run: |


### PR DESCRIPTION
## Summary
1. **Linode `-j` caps lifted after the runner resize** (2x CPU + RAM):
   - `omoq-ci-main.yml` asan debug (Linode): `-j6` → `-j$(nproc - 2)`
   - `omoq-ci-main.yml` publish (Linode bookworm-amd64 + GitHub-hosted siblings): `-j6` → `-j$(nproc - 2)`
2. **`omoq-ci-pr.yml` asan debug now routes to Linode for non-fork PRs.** Same self-hosted runner as ci-main, with persistent FetchContent + ccache. Fork PRs fall back to GitHub-hosted ubuntu (self-hosted on fork PRs needs per-run admin approval).
3. PR-CI asan-debug `-j6` (which never ran on Linode) drops the special-case; uses `-j$(nproc)` on the GitHub-hosted fallback path and `-j$(nproc - 2)` on Linode.

## Routing logic
- Matrix gains a `linode: true` flag on the asan-debug entry.
- `runs-on: ${{ (matrix.linode && !github.event.pull_request.head.repo.fork) && fromJSON('["self-hosted","linode"]') || matrix.runner }}`
- Job-level `USE_LINODE` env exposes the result for step-level `if:` conditionals (workspace cleanup, skip system-deps install, skip cache actions, FETCHCONTENT_BASE_DIR).

## Why combine into one PR
Lets this PR's own asan-debug job run on the resized Linode at `n-2`, validating the new cap before merge.

## Test plan
- [ ] PR CI green (linux, macos GitHub-hosted; asan debug on Linode)
- [ ] asan debug wall time visibly lower than the prior ~23 min on GitHub-hosted
- [ ] After merge, watch ci-main asan + bookworm-amd64 publish on the resized Linode for OOM-free completion

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/155)
<!-- Reviewable:end -->
