### PR TITLE
fix: null-guard WT callbacks in MoQServer::Handler after session end

### DIFF
--- a/moxygen/MoQServer.h
+++ b/moxygen/MoQServer.h
@@ -142,15 +142,21 @@ class MoQServer : public MoQServerBase {
     void onWebTransportBidiStream(
         proxygen::HTTPCodec::StreamID,
         proxygen::WebTransport::BidiStreamHandle handle) noexcept override {
-      clientSession_->onNewBidiStream(handle);
+      if (clientSession_) {
+        clientSession_->onNewBidiStream(handle);
+      }
     }
     void onWebTransportUniStream(
         proxygen::HTTPCodec::StreamID,
         proxygen::WebTransport::StreamReadHandle* handle) noexcept override {
-      clientSession_->onNewUniStream(handle);
+      if (clientSession_) {
+        clientSession_->onNewUniStream(handle);
+      }
     }
     void onDatagram(std::unique_ptr<folly::IOBuf> datagram) noexcept override {
-      clientSession_->onDatagram(std::move(datagram));
+      if (clientSession_) {
+        clientSession_->onDatagram(std::move(datagram));
+      }
     }
 
    private:


### PR DESCRIPTION
onWebTransportUniStream, onWebTransportBidiStream, and onDatagram all dereference clientSession_ without checking for null.  clientSession_ is reset in onSessionEnd, which fires when the proxygen session ends.  A race between the QUIC PeekLooper and ReadLooper can deliver WT stream or datagram callbacks after onSessionEnd has already nulled the pointer, causing a SIGSEGV.

Add null checks to all three callbacks so they are no-ops if the session has already been torn down.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/158)
<!-- Reviewable:end -->
