### PR TITLE
Mutable & immutable delta encoding fixup

### DIFF
--- a/moxygen/MoQFramer.cpp
+++ b/moxygen/MoQFramer.cpp
@@ -3239,6 +3239,8 @@ folly::Expected<folly::Unit, ErrorCode> MoQFrameParser::parseExtension(
             << " extLen=" << extLen->first;
         return folly::makeUnexpected(parseInnerResult.error());
       }
+      // Reset delta encoding state post-immutable.
+      previousExtensionType_ = kImmutableExtensionType;
       // Advance the outer cursor past the immutable container payload and
       // consume the bytes from the local length tracker
       cursor.skip(extLen->first);
@@ -3728,75 +3730,106 @@ void MoQFrameWriter::writeExtensions(
     size_t& size,
     bool& error,
     bool withLengthPrefix) const noexcept {
-  // Calculate total extension length (mutable + immutable blob if present)
-  auto mutableExtLen =
-      calculateExtensionVectorSize(extensions.getMutableExtensions(), error);
-  if (error) {
-    return;
-  }
-
-  size_t immutableBlobLen = 0;
-  size_t immutableExtensionsSize = 0; // Store calculated size for reuse
-  if (getDraftMajorVersion(*version_) >= 14 &&
-      !extensions.getImmutableExtensions().empty()) {
-    // Calculate size of immutable extensions blob:
-    // - Type (kImmutableExtensionType)
-    // - Length
-    // - Key-value pairs data
-    immutableExtensionsSize = calculateExtensionVectorSize(
+  // Get immutable length, if any.
+  const bool hasImmutableBlob = getDraftMajorVersion(*version_) >= 14 &&
+      !extensions.getImmutableExtensions().empty();
+  size_t immutableBodySize = 0;
+  if (hasImmutableBlob) {
+    immutableBodySize = calculateExtensionVectorSize(
         extensions.getImmutableExtensions(), error);
     if (error) {
       return;
     }
-
-    auto maybeTypeSize = quic::getQuicIntegerSize(kImmutableExtensionType);
-    if (maybeTypeSize.hasError()) {
-      error = true;
-      return;
-    }
-
-    auto maybeLengthSize = quic::getQuicIntegerSize(immutableExtensionsSize);
-    if (maybeLengthSize.hasError()) {
-      error = true;
-      return;
-    }
-
-    immutableBlobLen =
-        *maybeTypeSize + *maybeLengthSize + immutableExtensionsSize;
   }
 
-  auto totalExtLen = mutableExtLen + immutableBlobLen;
-  if (withLengthPrefix) {
-    writeVarint(writeBuf, totalExtLen, size, error);
+  folly::IOBufQueue blockBuf{folly::IOBufQueue::cacheChainLength()};
+  size_t blockSize = 0;
+
+  auto writeImmutableContainer = [&](uint64_t typeToWrite) {
+    writeVarint(blockBuf, typeToWrite, blockSize, error);
     if (error) {
       return;
     }
-  }
-
-  // Write mutable extensions first
-  writeKeyValuePairs(writeBuf, extensions.getMutableExtensions(), size, error);
-  if (error) {
-    return;
-  }
-
-  // Write immutable extensions blob if present
-  if (getDraftMajorVersion(*version_) >= 14 &&
-      !extensions.getImmutableExtensions().empty()) {
-    writeVarint(writeBuf, kImmutableExtensionType, size, error);
+    writeVarint(blockBuf, immutableBodySize, blockSize, error);
     if (error) {
       return;
     }
-
-    // Use the previously calculated size (no need to recalculate)
-    writeVarint(writeBuf, immutableExtensionsSize, size, error);
-    if (error) {
-      return;
-    }
-
-    // Write the immutable extensions as key-value pairs
     writeKeyValuePairs(
-        writeBuf, extensions.getImmutableExtensions(), size, error);
+        blockBuf, extensions.getImmutableExtensions(), blockSize, error);
+  };
+
+  if (getDraftMajorVersion(*version_) >= 16) {
+    auto sortedMutable =
+        sortExtensionsByType(extensions.getMutableExtensions());
+    uint64_t previousType = 0;
+    bool containerPlaced = false;
+    for (const auto& ext : sortedMutable) {
+      // Do we need to prepend immutable before going further?
+      if (hasImmutableBlob && !containerPlaced &&
+          ext.type > kImmutableExtensionType) {
+        writeImmutableContainer(kImmutableExtensionType - previousType);
+        if (error) {
+          return;
+        }
+        previousType = kImmutableExtensionType;
+        containerPlaced = true;
+      }
+
+      // Write the current mutable extension.
+      writeVarint(blockBuf, ext.type - previousType, blockSize, error);
+      if (error) {
+        return;
+      }
+      previousType = ext.type;
+      if (ext.isOddType()) {
+        auto dataLen =
+            ext.arrayValue ? ext.arrayValue->computeChainDataLength() : 0;
+        writeVarint(blockBuf, dataLen, blockSize, error);
+        if (error) {
+          return;
+        }
+        if (ext.arrayValue) {
+          blockBuf.append(ext.arrayValue->clone());
+          blockSize += dataLen;
+        }
+      } else {
+        writeVarint(blockBuf, ext.intValue, blockSize, error);
+        if (error) {
+          return;
+        }
+      }
+    }
+
+    // Otherwise, immutable is at the end.
+    if (hasImmutableBlob && !containerPlaced) {
+      writeImmutableContainer(kImmutableExtensionType - previousType);
+      if (error) {
+        return;
+      }
+    }
+  } else {
+    // v<16: no delta encoding, mutable extensions then immutable.
+    writeKeyValuePairs(
+        blockBuf, extensions.getMutableExtensions(), blockSize, error);
+    if (error) {
+      return;
+    }
+    if (hasImmutableBlob) {
+      writeImmutableContainer(kImmutableExtensionType);
+      if (error) {
+        return;
+      }
+    }
   }
+
+  if (withLengthPrefix) {
+    writeVarint(writeBuf, blockSize, size, error);
+    if (error) {
+      return;
+    }
+  }
+  writeBuf.append(blockBuf.move());
+  size += blockSize;
 }
 
 size_t MoQFrameWriter::calculateExtensionVectorSize(

--- a/moxygen/test/MoQFramerTest.cpp
+++ b/moxygen/test/MoQFramerTest.cpp
@@ -1843,6 +1843,10 @@ class MoQImmutableExtensionsTest : public ::testing::TestWithParam<uint64_t> {
   MoQFrameParser parser_;
   MoQFrameWriter writer_;
 
+  bool deltaEncoding() const {
+    return getDraftMajorVersion(GetParam()) >= 16;
+  }
+
   // Creates the following extensions (encoded back-to-back):
   // {type = 20, value = 100, immutable}
   // {type = 21, value = binary(0xAB,0xCD,0xEF), immutable}
@@ -1856,7 +1860,7 @@ class MoQImmutableExtensionsTest : public ::testing::TestWithParam<uint64_t> {
 
     // Extension type 21 (odd => length + bytes), binary value
     static uint8_t testData[] = {0xAB, 0xCD, 0xEF};
-    writeVarintTo(immutableBuf, 21);                 // type
+    writeVarintTo(immutableBuf, deltaEncoding() ? 21 - 20 : 21); // type
     writeVarintTo(immutableBuf, sizeof(testData));   // length
     immutableBuf.append(testData, sizeof(testData)); // data
 
@@ -1868,25 +1872,33 @@ class MoQImmutableExtensionsTest : public ::testing::TestWithParam<uint64_t> {
   // type = kImmutableExtensionType (odd) and an arbitrary byte value. This is
   // invalid when parsed as nested immutable extensions (parseImmutable=false).
   std::unique_ptr<folly::IOBuf> createImmutableExtensionsBufMalformed() {
-    // Start with the valid immutable extensions blob
-    auto base = createImmutableExtensionsBuf();
-
     // Append an additional immutable-extensions container entry with arbitrary
     // 1-byte payload. This makes the nested immutable blob malformed for our
     // parser (immutable container found while already parsing immutable).
     folly::IOBufQueue q{folly::IOBufQueue::cacheChainLength()};
 
-    if (base) {
-      q.append(std::move(base));
+    if (deltaEncoding()) {
+      // Different path to support delta encoding.
+      writeVarintTo(q, 2); // type
+      writeVarintTo(q, 1); // value
+      writeVarintTo(q, kImmutableExtensionType - 2); // nested
+      writeVarintTo(q, 1);                           // length
+      static const uint8_t kArbitrary = 0xAA;
+      q.append(&kArbitrary, 1);
+    } else {
+      auto base = createImmutableExtensionsBuf();
+      if (base) {
+        q.append(std::move(base));
+      }
+
+      // Write type = kImmutableExtensionType (odd)
+      writeVarintTo(q, kImmutableExtensionType);
+
+      // Write length = 1, then one arbitrary byte value 0xAA
+      writeVarintTo(q, 1); // length
+      static const uint8_t kArbitrary = 0xAA;
+      q.append(&kArbitrary, 1);
     }
-
-    // Write type = kImmutableExtensionType (odd)
-    writeVarintTo(q, kImmutableExtensionType);
-
-    // Write length = 1, then one arbitrary byte value 0xAA
-    writeVarintTo(q, 1); // length
-    static const uint8_t kArbitrary = 0xAA;
-    q.append(&kArbitrary, 1);
 
     return q.move();
   }
@@ -1906,14 +1918,14 @@ class MoQImmutableExtensionsTest : public ::testing::TestWithParam<uint64_t> {
     // 2) type = kImmutableExtensionType (odd => length + bytes), value =
     //    output of createImmutableExtensionsBuf()
     auto imm = createImmutableExtensionsBuf();
-    writeVarintTo(buf, kImmutableExtensionType);                 // type
+    writeVarintTo(buf, deltaEncoding() ? kImmutableExtensionType - 10 : kImmutableExtensionType); // type
     writeVarintTo(buf, imm ? imm->computeChainDataLength() : 0); // length
     if (imm) {
       buf.append(std::move(imm)); // payload
     }
 
     // 3) type = 30 (even => integer value follows), value = 999
-    writeVarintTo(buf, 30);  // type
+    writeVarintTo(buf, deltaEncoding() ? 30 - kImmutableExtensionType : 30); // type
     writeVarintTo(buf, 999); // value
 
     return buf.move();
@@ -1932,14 +1944,14 @@ class MoQImmutableExtensionsTest : public ::testing::TestWithParam<uint64_t> {
     // 2) type = kImmutableExtensionType (odd => length + bytes), value =
     //    output of createImmutableExtensionsBufMalformed()
     auto imm = createImmutableExtensionsBufMalformed();
-    writeVarintTo(buf, kImmutableExtensionType);                 // type
+    writeVarintTo(buf, deltaEncoding() ? kImmutableExtensionType - 10 : kImmutableExtensionType); // type
     writeVarintTo(buf, imm ? imm->computeChainDataLength() : 0); // length
     if (imm) {
       buf.append(std::move(imm)); // payload
     }
 
     // 3) type = 30 (even => integer value follows), value = 999
-    writeVarintTo(buf, 30);  // type
+    writeVarintTo(buf, deltaEncoding() ? 30 - kImmutableExtensionType : 30); // type
     writeVarintTo(buf, 999); // value
 
     return buf.move();
@@ -2025,9 +2037,11 @@ TEST_P(MoQImmutableExtensionsTest, WriteImmutableExtensionsDraft) {
 
   static const uint8_t kTestBinary[] = {0xAB, 0xCD, 0xEF};
   std::vector<Extension> immutableExts = {
+      Extension{2, 2},
       Extension{20, 100},
       Extension{
-          21, folly::IOBuf::copyBuffer(kTestBinary, sizeof(kTestBinary))}};
+          21, folly::IOBuf::copyBuffer(kTestBinary, sizeof(kTestBinary))},
+      Extension{32, 32}};
 
   Extensions extensions(mutableExts, immutableExts);
 
@@ -2056,8 +2070,8 @@ TEST_P(MoQImmutableExtensionsTest, WriteImmutableExtensionsDraft) {
   EXPECT_TRUE(parseResult.hasValue()) << "Parsing should succeed";
 
   // Verify both mutable and immutable extensions are present
-  EXPECT_EQ(obj.extensions.size(), 4)
-      << "Should have 4 total extensions (2 mutable + 2 immutable)";
+  EXPECT_EQ(obj.extensions.size(), 6)
+      << "Should have 6 total extensions (2 mutable + 4 immutable)";
   EXPECT_THAT(
       obj.extensions.getMutableExtensions(), testing::ContainerEq(mutableExts));
   EXPECT_THAT(
@@ -2114,7 +2128,7 @@ TEST_P(MoQImmutableExtensionsTest, WriteOnlyImmutableExtensionsDraft) {
 INSTANTIATE_TEST_SUITE_P(
     MoQImmutableExtensionsTest,
     MoQImmutableExtensionsTest,
-    ::testing::Values(kVersionDraft14, kVersionDraft15));
+    ::testing::Values(kVersionDraft14, kVersionDraft15, kVersionDraft16));
 
 TEST_P(MoQFramerTest, DatagramWithExtensionsAndNonNormalStatus) {
   folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};


### PR DESCRIPTION
I believe there are 2 issues around extension coding that arise when both mutable AND immutable headers are present. This is my first time in moxygen code, so apologies if I've gone wrong.

On the parsing side, `parseExtensionKvPairs` is recursively called to handle the immutable blob. `previousExtensionType_` is reset to 0 in order to correctly re-key the delta encoding, but it is not reset after parsing the immutable headers. This means that the next mutable extension after the immutable blob will be delta encoded relative to the last immutable extension key, not the immutable extension key itself (0xB).

Secondly, the writing appears to always append immutable extensions after mutable ones, with an absolute key, in >=16. My understanding is that the encoded blob should be encoded like any other KVP, and with a delta encoding of the type.

There are tests to catch this, but they did not support >= draft-16 / delta encoding, so I updated them as well, and they fail as expected without the fix. I also added some extra KVPs to cover some other cases that shouldn't happen like backwards encoding into and out of the immutable blob, just for some additional coverage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/162)
<!-- Reviewable:end -->
