### PR TITLE
ci: skip test-reporter on fork PRs; explain in annotation

### DIFF
--- a/.github/workflows/omoq-ci-pr.yml
+++ b/.github/workflows/omoq-ci-pr.yml
@@ -109,13 +109,21 @@ jobs:
           ASAN_OPTIONS: ${{ matrix.name == 'asan debug' && 'detect_leaks=1:abort_on_error=1' || '' }}
         run: ctest --test-dir _build --output-on-failure --output-junit test-results.xml
 
+      # dorny/test-reporter writes a Check Run, which needs 'checks: write' on
+      # GITHUB_TOKEN. Fork-PR tokens are read-only regardless of workflow perms,
+      # so skip on cross-repo PRs. ctest output above still shows pass/fail.
       - name: Publish test results
         uses: dorny/test-reporter@v1.9.1
-        if: success() || failure()
+        if: ${{ (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         with:
           name: "test (${{ matrix.name }})"
           path: _build/test-results.xml
           reporter: java-junit
+
+      - name: Note fork-PR reporter skip
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          echo "::notice::Publish test results skipped — fork-PR GITHUB_TOKEN lacks checks:write. ctest output above is authoritative."
 
       - name: Install (smoke test)
         if: matrix.name != 'asan debug'


### PR DESCRIPTION
## Summary
Fork PRs (e.g. #162 from RichLogan) fail CI at the \`Publish test results\` step because \`dorny/test-reporter\` writes a GitHub Check Run — which requires \`checks: write\` on \`GITHUB_TOKEN\`. Fork-PR tokens are **read-only by GitHub security policy** regardless of what the workflow's \`permissions\` block declares. The actual build + tests pass; just the annotator fails, turning the PR red.

## Change
Guard the reporter step with an \`if:\` that skips it when the PR head repo differs from the base repo (i.e. fork PR). Same-repo PRs, \`main\` pushes, and sync PRs still get the annotations as before.

Add a sibling \`Note fork-PR reporter skip\` step that runs *only* on fork PRs and emits a \`::notice::\` annotation explaining why — so the skip shows up in the PR's Files/Actions view with context, not just a gray "Skipped" with no hint.

## Effect
- **Same-repo PRs / sync PRs**: no change. Reporter runs, annotations posted.
- **Fork PRs**: reporter step shows Skipped (gray); a notice annotation explains the reason. \`ctest\` output above remains authoritative for pass/fail. Job goes green when tests pass.

## Test plan
- [x] CI green on this PR (internal branch — reporter still runs)
- [ ] After merge: RichLogan's #162 (or next fork PR) runs clean with notice visible and green overall
- [ ] Same-repo PRs continue to see the test-reporter Check Run on Files view

## Follow-up
Same guard wants mirroring to \`openmoq/moqx/.github/workflows/ci-pr.yml\` (has the same reporter step). Separate PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/164)
<!-- Reviewable:end -->
