### PR TITLE
fix(pico): tolerate missing WT subprotocol; fall back to in-band ClientSetup

### DIFF
--- a/moxygen/openmoq/transport/pico/MoQPicoServerBase.cpp
+++ b/moxygen/openmoq/transport/pico/MoQPicoServerBase.cpp
@@ -586,9 +586,8 @@ int MoQPicoServerBase::onWebTransportConnectImpl(
     XLOG(DBG1) << "WebTransport selected protocol: " << selectedProto;
     moqSession->validateAndSetVersionFromAlpn(selectedProto);
   } else {
-    XLOG(ERR)
-        << "No compatible WT protocol - client didn't offer matching version";
-    return -1;
+    // No WT subprotocol negotiated; fall back to in-band ClientSetup.
+    XLOG(DBG1) << "WT subprotocol not negotiated; using in-band ClientSetup";
   }
 
   // Store session context on the control stream. Data streams inherit it via


### PR DESCRIPTION
## Summary

Fixes #172.

The picoquic-side WT CONNECT handler required `picowt_select_wt_protocol` to negotiate a subprotocol via `Sec-WebTransport-WT-Available-Protocols` — a draft-16+ feature. Draft-14 clients don't send that header, so `onWebTransportConnectImpl` returned -1 and h3zero answered HTTP 501. WT CONNECT failed before MoQT could negotiate a version.

The mvfst transport already tolerates the missing header and falls back to in-band MoQT version negotiation in the ClientSetup on the control stream. This change matches that behavior on the picoquic transport: log a debug and continue when no subprotocol is selected.

## Test plan

- aiomoqt `pub_bench --draft 14 https://<host>:4434/moq-pico-relay --pub-both`: WT CONNECT now accepted (was 501), MoQT setup proceeds via ClientSetup, PUBLISH flow works end-to-end.
- aiomoqt `multi_sub_bench --draft 14 -P 1 --pub-both -n 10 -s 16384 -r 60 -t 60 --stagger 0.1`: 10/10 subscribers ok, 0 errors, 78.7 Mbps total, ~5 ms latency.
- mvfst path is unchanged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/173)
<!-- Reviewable:end -->
