### PR TITLE
ci: support release/** branches with branch-derived snapshot tags

### DIFF
--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -1,7 +1,11 @@
 name: ci main
 
-# Full pipeline on push to main: build/test, publish BUNDLE_DEPS artifacts,
-# release snapshot, notify. PRs use omoq-ci-pr.yml (build/test only).
+# Full pipeline on push to main or release/** branches: build/test, publish
+# BUNDLE_DEPS artifacts, release snapshot, notify. PRs use omoq-ci-pr.yml
+# (build/test only).
+#
+# main           → snapshot-latest pre-release
+# release/<lbl>  → snapshot-<lbl>-latest pre-release (independent namespace)
 #
 # Job graph:
 #
@@ -10,7 +14,7 @@ name: ci main
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/**']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -121,7 +125,7 @@ jobs:
         run: cmake --install _build
 
   # ════════════════════════════════════════════════════════════════════════════
-  # Publish: BUNDLE_DEPS artifact builds (main only, needs verify to pass)
+  # Publish: BUNDLE_DEPS artifact builds (needs verify to pass)
   # ════════════════════════════════════════════════════════════════════════════
 
   publish:
@@ -248,12 +252,16 @@ jobs:
           retention-days: 90
 
   # ════════════════════════════════════════════════════════════════════════════
-  # Release: create/update snapshot-latest pre-release (main only, all green)
+  # Release: create/update branch-derived snapshot pre-release (all green)
+  #   main           → snapshot-latest
+  #   release/<lbl>  → snapshot-<lbl>-latest
   # ════════════════════════════════════════════════════════════════════════════
 
   release:
     needs: [build, publish]
     runs-on: ubuntu-22.04
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
 
@@ -262,16 +270,32 @@ jobs:
         with:
           path: artifacts/
 
+      - name: Compute release tag
+        id: tag
+        run: |
+          BRANCH="${{ github.ref_name }}"
+          if [ "$BRANCH" = "main" ]; then
+            TAG="snapshot-latest"
+          else
+            # release/nab-demo → snapshot-nab-demo-latest
+            LABEL="${BRANCH#release/}"
+            TAG="snapshot-${LABEL}-latest"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Release tag: $TAG (branch: $BRANCH)"
+
       - name: Publish snapshot
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash openmoq/scripts/publish-artifacts.sh \
             --artifacts-dir artifacts/ \
-            --sha "$GITHUB_SHA"
+            --sha "$GITHUB_SHA" \
+            --tag "${{ steps.tag.outputs.tag }}" \
+            --branch "${{ github.ref_name }}"
 
   # ════════════════════════════════════════════════════════════════════════════
-  # Notify: aggregate status (main only, runs after everything)
+  # Notify: aggregate status (runs after everything)
   # ════════════════════════════════════════════════════════════════════════════
 
   notify:
@@ -279,9 +303,9 @@ jobs:
     if: always()
     runs-on: ubuntu-22.04
     steps:
-      # ── Dispatch submodule update to moqx (on successful release) ──
+      # ── Dispatch submodule update to moqx (only from main) ──
       - name: Generate moqx app token
-        if: needs.release.result == 'success'
+        if: needs.release.result == 'success' && github.ref_name == 'main'
         id: moqx-token
         uses: actions/create-github-app-token@v2
         with:
@@ -290,7 +314,7 @@ jobs:
           repositories: moqx
 
       - name: Dispatch moxygen sync to moqx
-        if: needs.release.result == 'success'
+        if: needs.release.result == 'success' && github.ref_name == 'main'
         env:
           GH_TOKEN: ${{ steps.moqx-token.outputs.token }}
         run: |
@@ -328,7 +352,7 @@ jobs:
           STATUS="verify:${VER} publish:${PUB} release:${REL}"
 
           if [ "${{ needs.release.result }}" = "success" ]; then
-            REL_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/snapshot-latest"
+            REL_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.release.outputs.tag }}"
             TEXT=":white_check_mark: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — ${STATUS}  <${RUN_URL}|#${{ github.run_number }}> artifacts: <${REL_URL}|view>"
           else
             TEXT=":x: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — ${STATUS}  <${RUN_URL}|#${{ github.run_number }}>"
@@ -355,7 +379,7 @@ jobs:
           STATUS="verify:${VER} publish:${PUB} release:${REL}"
 
           if [ "${{ needs.release.result }}" = "success" ]; then
-            REL_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/snapshot-latest"
+            REL_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.release.outputs.tag }}"
             SUBJECT="[moxygen] published ${{ github.ref_name }} ${SHORT}"
             BODY="Repository: ${{ github.repository }}\nBranch: ${{ github.ref_name }}\nCommit: ${GITHUB_SHA}\nStatus: ${STATUS}\nArtifacts: ${REL_URL}\nRun: ${RUN_URL}"
           else

--- a/openmoq/scripts/publish-artifacts.sh
+++ b/openmoq/scripts/publish-artifacts.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 ARTIFACTS_DIR=""
 SHA=""
 TAG="snapshot-latest"
+BRANCH="main"
 REPO=""  # defaults to current repo if empty
 DRY_RUN=false
 
@@ -30,6 +31,8 @@ Usage: $(basename "$0") --artifacts-dir DIR --sha SHA [OPTIONS]
 Options:
   --artifacts-dir DIR   Directory containing .tar.gz artifact files
   --sha SHA             Full commit SHA for the release
+  --tag TAG             Pre-release tag name (default: snapshot-latest)
+  --branch BRANCH       Source branch name for release notes (default: main)
   --repo OWNER/REPO     GitHub repository (default: current repo from gh)
   --dry-run             Show what would be done without creating the release
   -h, --help            Show this help
@@ -41,6 +44,8 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --artifacts-dir) ARTIFACTS_DIR="$2"; shift 2 ;;
     --sha)           SHA="$2"; shift 2 ;;
+    --tag)           TAG="$2"; shift 2 ;;
+    --branch)        BRANCH="$2"; shift 2 ;;
     --repo)          REPO="$2"; shift 2 ;;
     --dry-run)       DRY_RUN=true; shift ;;
     -h|--help)       usage 0 ;;
@@ -130,15 +135,15 @@ else
   # shellcheck disable=SC2086
   gh release create "$TAG" \
     --target "$SHA" \
-    --title "Latest build ($SHORT_SHA)" \
+    --title "Latest build — ${BRANCH} (${SHORT_SHA})" \
     --prerelease \
     --notes "$(cat <<EOF
-Rolling snapshot of the latest build from \`main\`.
+Rolling snapshot of the latest build from \`${BRANCH}\`.
 
 **Commit:** \`${SHA}\`
 **Built:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-This pre-release is automatically replaced on every push to \`main\`.
+This pre-release is automatically replaced on every push to \`${BRANCH}\`.
 
 Each platform has two tarballs:
 - \`moxygen-<platform>.tar.gz\` — stripped release build


### PR DESCRIPTION
## Summary

Adds `release/**` branch support to the publish pipeline, mirroring the openmoq/moqx pattern. Useful for verifying production-track tarball changes (Track A in #249's discussion) on a release branch without touching `snapshot-latest`.

| Branch | Pre-release tag |
|---|---|
| `main` | `snapshot-latest` (unchanged) |
| `release/<label>` | `snapshot-<label>-latest` |

Three independent namespaces — no conflict with the existing tagged version releases:

| Trigger | Workflow | Output |
|---|---|---|
| `workflow_dispatch` | `omoq-version-release.yml` | tagged versions (`v1.2.3`) |
| `push: main` | `omoq-ci-main.yml` | `snapshot-latest` |
| `push: release/**` | `omoq-ci-main.yml` | `snapshot-<label>-latest` |

## Changes

- `omoq-ci-main.yml`: trigger now `[main, 'release/**']`. New `Compute release tag` step derives the tag from `github.ref_name`. Notify-job URLs use the derived tag via job output.
- `openmoq/scripts/publish-artifacts.sh`: new `--tag` and `--branch` flags. Notes/title now reflect the actual source branch.
- moqx submodule-update dispatch in the notify job is gated on `github.ref_name == 'main'` — release branches shouldn't trigger downstream sync.

## Test plan

- [ ] After merge, push a `release/test-x` branch with a no-op commit; confirm a `snapshot-test-x-latest` pre-release is created with all expected assets, and `snapshot-latest` is unchanged.
- [ ] Confirm notify Slack/email URLs point at the right tag.
- [ ] Confirm the moqx-update dispatch does NOT fire from `release/*`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/179)
<!-- Reviewable:end -->
