### PR TITLE
deps: pin openmoq/picoquic via rev file + auto-bump workflow

### DIFF
--- a/.github/workflows/omoq-auto-merge-sync.yml
+++ b/.github/workflows/omoq-auto-merge-sync.yml
@@ -15,6 +15,7 @@ on:
     types: [completed]
     branches:
       - sync/**
+      - sync-picoquic/**
 
 permissions:
   contents: write
@@ -23,7 +24,7 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-22.04
-    if: startsWith(github.event.workflow_run.head_branch, 'sync/')
+    if: startsWith(github.event.workflow_run.head_branch, 'sync/') || startsWith(github.event.workflow_run.head_branch, 'sync-picoquic/')
     steps:
       - name: Find sync PR
         id: find-pr

--- a/.github/workflows/omoq-picoquic-bump.yml
+++ b/.github/workflows/omoq-picoquic-bump.yml
@@ -1,0 +1,166 @@
+name: picoquic bump
+
+# Watches openmoq/picoquic main and opens a PR bumping
+# build/deps/github_hashes/openmoq/picoquic-rev.txt when the pin falls
+# behind. CI gates the merge — same auto-merge wiring as upstream sync.
+#
+# To halt automatic bumps on a release branch, just don't run this
+# workflow on that branch (cron is on default branch only) and don't
+# merge any sync-picoquic/* PRs that get opened.
+
+on:
+  schedule:
+    - cron: '30 9 * * *'   # Daily at 04:30 ET (09:30 UTC) — offset from upstream-sync (07:00) and picoquic-side sync (08:15)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OMOQ_APP_ID }}
+          private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      # ── Block if an existing bump PR is open ─────────────────────────────
+      - name: Check for open picoquic-bump PR
+        id: blocking
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          PR=$(gh api "repos/${{ github.repository }}/pulls?state=open&base=main" \
+            --jq '[.[] | select(.head.ref | startswith("sync-picoquic/"))] | .[0] // empty')
+          if [ -n "$PR" ]; then
+            PR_NUM=$(echo "$PR" | jq -r '.number')
+            PR_REF=$(echo "$PR" | jq -r '.head.ref')
+            echo "::warning::Bump blocked — open PR #$PR_NUM ($PR_REF) pending."
+            echo "blocked=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "blocked=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ── Read current pin and compare to openmoq/picoquic main ────────────
+      - name: Compare pin to picoquic main
+        if: steps.blocking.outputs.blocked == 'false'
+        id: compare
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          REV_FILE="build/deps/github_hashes/openmoq/picoquic-rev.txt"
+          CURRENT_SHA=$(grep -oE '[a-fA-F0-9]{40}' "$REV_FILE" | head -1)
+          NEW_SHA=$(gh api repos/openmoq/picoquic/branches/main --jq '.commit.sha')
+
+          echo "Current pin: $CURRENT_SHA"
+          echo "picoquic main: $NEW_SHA"
+
+          if [ "$CURRENT_SHA" = "$NEW_SHA" ]; then
+            echo "Pin is up to date. Nothing to do."
+            echo "needs_bump=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "needs_bump=true" >> "$GITHUB_OUTPUT"
+            echo "current_sha=$CURRENT_SHA" >> "$GITHUB_OUTPUT"
+            echo "new_sha=$NEW_SHA" >> "$GITHUB_OUTPUT"
+            echo "short_sha=${NEW_SHA:0:12}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ── Create bump branch + PR ──────────────────────────────────────────
+      - name: Create bump branch and PR
+        if: steps.blocking.outputs.blocked == 'false' && steps.compare.outputs.needs_bump == 'true'
+        id: new_pr
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          NEW_SHA="${{ steps.compare.outputs.new_sha }}"
+          CURRENT_SHA="${{ steps.compare.outputs.current_sha }}"
+          SHORT_SHA="${{ steps.compare.outputs.short_sha }}"
+          CURRENT_SHORT="${CURRENT_SHA:0:12}"
+          BRANCH="sync-picoquic/$SHORT_SHA"
+
+          git config user.email "omoq-sync-bot[bot]@users.noreply.github.com"
+          git config user.name "omoq-sync-bot[bot]"
+          git checkout -b "$BRANCH"
+
+          echo "Subproject commit $NEW_SHA" > build/deps/github_hashes/openmoq/picoquic-rev.txt
+          git add build/deps/github_hashes/openmoq/picoquic-rev.txt
+          git commit -m "deps: bump openmoq/picoquic pin to $SHORT_SHA"
+          git push origin "$BRANCH"
+
+          PR_NUM=$(gh api repos/${{ github.repository }}/pulls \
+            -f title="deps: bump openmoq/picoquic pin to $SHORT_SHA" \
+            -f body="$(cat <<EOF
+          Automated picoquic pin bump.
+
+          - **From:** [\`${CURRENT_SHORT}\`](https://github.com/openmoq/picoquic/commit/$CURRENT_SHA)
+          - **To:** [\`${SHORT_SHA}\`](https://github.com/openmoq/picoquic/commit/$NEW_SHA)
+          - **Compare:** https://github.com/openmoq/picoquic/compare/${CURRENT_SHA}...${NEW_SHA}
+
+          The PR CI workflow validates the standalone build against the new pin. On success, this PR auto-merges.
+
+          To halt picoquic auto-bumps temporarily, close this PR — the file holds the pin until a future bump PR is merged.
+
+          Created by \`omoq-picoquic-bump\` workflow.
+          EOF
+          )" \
+            -f head="$BRANCH" \
+            -f base="main" \
+            --jq '.number')
+
+          echo "Created bump PR #$PR_NUM"
+          echo "pr_num=$PR_NUM" >> "$GITHUB_OUTPUT"
+
+      # ── Approve so auto-merge can proceed ────────────────────────────────
+      - name: Approve PR
+        if: steps.blocking.outputs.blocked == 'false' && steps.compare.outputs.needs_bump == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.OMOQ_SYNC_TOKEN }}
+        run: |
+          PR_NUM="${{ steps.new_pr.outputs.pr_num }}"
+          [ -z "$PR_NUM" ] && { echo "::warning::No PR number"; exit 0; }
+          gh api repos/${{ github.repository }}/pulls/$PR_NUM/reviews \
+            -f event=APPROVE \
+            -f body="Auto-approved by picoquic-bump workflow." \
+            --jq '.state'
+
+      # ── Failure notifications ────────────────────────────────────────────
+      - name: Notify Slack (bump failure)
+        if: failure()
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.OMOQ_SLACK_WEBHOOK_URL }}
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          TEXT=":warning: *${{ github.repository }}* — picoquic bump workflow failed: Run <${RUN_URL}|#${{ github.run_number }}>"
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            --data "{\"text\": \"${TEXT}\"}"
+
+      - name: Notify email (bump failure)
+        if: failure()
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.OMOQ_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.OMOQ_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SUBJECT="[moxygen] picoquic bump FAILED"
+          BODY="picoquic bump workflow failed.\n\nRun: ${RUN_URL}"
+          aws ses send-email \
+            --from "noreply@ci.openmoq.org" \
+            --destination '{"ToAddresses":["github-notifications@openmoq.org"]}' \
+            --message "{
+              \"Subject\": {\"Data\": \"${SUBJECT}\"},
+              \"Body\": {\"Text\": {\"Data\": \"${BODY}\"}}
+            }"

--- a/build/deps/github_hashes/openmoq/picoquic-rev.txt
+++ b/build/deps/github_hashes/openmoq/picoquic-rev.txt
@@ -1,0 +1,1 @@
+Subproject commit cb0aac6a11bdd5a449166e036ce3bc120f94b9c9

--- a/moxygen/openmoq/transport/pico/CMakeLists.txt
+++ b/moxygen/openmoq/transport/pico/CMakeLists.txt
@@ -11,9 +11,26 @@ moxygen_add_library(openmoq_pico_base
     Folly::folly_logging_logging
     Folly::folly_network_address
     Folly::folly_string
+)
+# Upstream picoquic master added picoquic_set_qlog() calls inside
+# picoquic/sockloop.c (picoquic-core), but the symbol is defined in
+# loglib/qlog_fns.c (picoquic-log) — which already PUBLIC-links
+# picoquic-core. Cyclic static dep. GNU ld processes the link line
+# left-to-right and won't rescan, so wrap the pair in --start-group/
+# --end-group on Linux. ld64 (macOS) rescans by default.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  target_link_libraries(openmoq_pico_base PUBLIC
+    "-Wl,--start-group"
     picoquic::picoquic-core
     picoquic-log
-)
+    "-Wl,--end-group"
+  )
+else()
+  target_link_libraries(openmoq_pico_base PUBLIC
+    picoquic::picoquic-core
+    picoquic-log
+  )
+endif()
 # PicoConnectionContext.h includes PicoH3WebTransport.h which needs h3zero.
 # Propagate picohttp include path to all consumers via BUILD_INTERFACE
 # (avoids CMake policy error for build-dir paths in INTERFACE_INCLUDE_DIRECTORIES).

--- a/moxygen/openmoq/transport/pico/CMakeLists.txt
+++ b/moxygen/openmoq/transport/pico/CMakeLists.txt
@@ -17,13 +17,11 @@ moxygen_add_library(openmoq_pico_base
 # loglib/qlog_fns.c (picoquic-log) — which already PUBLIC-links
 # picoquic-core. Cyclic static dep. GNU ld processes the link line
 # left-to-right and won't rescan, so wrap the pair in --start-group/
-# --end-group on Linux. ld64 (macOS) rescans by default.
+# --end-group on Linux via $<LINK_GROUP:RESCAN,...> (cmake 3.24+,
+# dedupe-safe). ld64 (macOS) rescans by default.
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   target_link_libraries(openmoq_pico_base PUBLIC
-    "-Wl,--start-group"
-    picoquic::picoquic-core
-    picoquic-log
-    "-Wl,--end-group"
+    "$<LINK_GROUP:RESCAN,picoquic::picoquic-core,picoquic-log>"
   )
 else()
   target_link_libraries(openmoq_pico_base PUBLIC

--- a/moxygen/openmoq/transport/pico/CMakeLists.txt
+++ b/moxygen/openmoq/transport/pico/CMakeLists.txt
@@ -12,6 +12,7 @@ moxygen_add_library(openmoq_pico_base
     Folly::folly_network_address
     Folly::folly_string
     picoquic::picoquic-core
+    picoquic-log
 )
 # PicoConnectionContext.h includes PicoH3WebTransport.h which needs h3zero.
 # Propagate picohttp include path to all consumers via BUILD_INTERFACE

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -83,6 +83,7 @@ read_rev_hash("facebookincubator" "fizz" FIZZ_REV)
 read_rev_hash("facebook" "wangle" WANGLE_REV)
 read_rev_hash("facebook" "mvfst" MVFST_REV)
 read_rev_hash("facebook" "proxygen" PROXYGEN_REV)
+read_rev_hash("openmoq" "picoquic" PICOQUIC_REV)
 
 # =============================================================================
 # System Dependencies (must be pre-installed)
@@ -271,9 +272,12 @@ FetchContent_Declare(proxygen
 )
 
 if(BUILD_PICOQUIC)
+    # Pinned to a SHA on openmoq/picoquic main; auto-bumped by
+    # .github/workflows/omoq-picoquic-bump.yml (opens a PR when the pin
+    # falls behind openmoq/picoquic main; CI gates the merge).
     FetchContent_Declare(picoquic
-        GIT_REPOSITORY https://github.com/afrind/picoquic.git
-        GIT_TAG openmoq-main
+        GIT_REPOSITORY https://github.com/openmoq/picoquic.git
+        GIT_TAG ${PICOQUIC_REV}
     )
 endif()
 


### PR DESCRIPTION
## Summary

- Switches picoquic FetchContent source from `afrind/picoquic openmoq-main` (stale tracking branch) to `openmoq/picoquic` at a SHA pinned in `build/deps/github_hashes/openmoq/picoquic-rev.txt` — same convention as folly/fizz/wangle/mvfst/proxygen.
- New `omoq-picoquic-bump.yml`: daily cron (09:30 UTC, offset from upstream-sync at 07:00 UTC) checks `openmoq/picoquic` main and opens a `sync-picoquic/<sha>` PR when the pin falls behind. PR CI gates the merge.
- Extends `omoq-auto-merge-sync.yml` filter so `sync-picoquic/**` PRs auto-merge on green CI alongside the existing `sync/**` flow.

Naming follows the established convention: a repo's own upstream sync is `sync/<sha>`; cross-repo dep bumps are `sync-<dep>/<sha>` (matches moqx's `sync-moxygen/<sha>`).

## Halt mechanism

Don't merge an open `sync-picoquic/*` PR — the pin file holds the current SHA. Useful for release branches if/when we cut them.

## Test plan

- [ ] Standalone CI green: confirms `read_rev_hash("openmoq" "picoquic" PICOQUIC_REV)` parses the pin file and FetchContent pulls `openmoq/picoquic` at that SHA.
- [ ] Manual `workflow_dispatch` of `picoquic bump` after merge — verify it sees pin == current main and exits cleanly with no PR opened.
- [ ] Once `openmoq/picoquic` advances (via its own daily upstream-sync), confirm the next cron-tick of this workflow opens a `sync-picoquic/<sha>` PR and that auto-merge takes over after PR CI passes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/187)
<!-- Reviewable:end -->
