### PR TITLE
revert: #184 portable linux tarballs (broke moqx tarball find_package(GTest))

### DIFF
--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -134,28 +134,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Linux RelWithDebInfo entries: keep frame pointers preserved so
-          # signal-handler stack unwinding (folly::symbolizer) and post-mortem
-          # debugging via the -dbg sidecar work reliably under -O2.
           - name: ubuntu-22.04-amd64
             runner: ubuntu-22.04
-            build_type: RelWithDebInfo
-            cxx_flags: "-fno-omit-frame-pointer -fasynchronous-unwind-tables"
             artifact: moxygen-ubuntu-22.04-amd64.tar.gz
             debug_artifact: moxygen-ubuntu-22.04-amd64-dbg.tar.gz
             container: ""
 
           - name: macos-15-arm64
             runner: macos-15
-            build_type: RelWithDebInfo
             artifact: moxygen-macos-15-arm64.tar.gz
             debug_artifact: moxygen-macos-15-arm64-dbg.tar.gz
             container: ""
 
           - name: bookworm-amd64
             runner: [self-hosted, linode]
-            build_type: RelWithDebInfo
-            cxx_flags: "-fno-omit-frame-pointer -fasynchronous-unwind-tables"
             artifact: moxygen-bookworm-amd64.tar.gz
             debug_artifact: moxygen-bookworm-amd64-dbg.tar.gz
             container: debian:bookworm
@@ -163,35 +155,9 @@ jobs:
 
           - name: bookworm-arm64
             runner: ubuntu-22.04-arm
-            build_type: RelWithDebInfo
-            cxx_flags: "-fno-omit-frame-pointer -fasynchronous-unwind-tables"
             artifact: moxygen-bookworm-arm64.tar.gz
             debug_artifact: moxygen-bookworm-arm64-dbg.tar.gz
             container: debian:bookworm
-
-          # ── Portable Linux production tarballs ──
-          # Release build on jammy base, statically linked for cross-distro
-          # compatibility. cxx_flags pin the ISA baseline:
-          #   x86-64-v2 = SSE4.2+POPCNT (≈ all cloud x86 since 2015)
-          #   armv8-a   = base ARMv8.0 (covers Graviton 1-4, Ampere, Apple M,
-          #               RPi 3/4/5, Rockchip RK3399 + RK3588 / Orange Pi)
-          - name: linux-amd64
-            runner: ubuntu-22.04
-            build_type: Release
-            cxx_flags: "-march=x86-64-v2"
-            static_syslibs: "ON"
-            artifact: moxygen-linux-amd64.tar.gz
-            debug_artifact: moxygen-linux-amd64-symbols.tar.gz
-            container: ""
-
-          - name: linux-arm64
-            runner: ubuntu-22.04-arm
-            build_type: Release
-            cxx_flags: "-march=armv8-a"
-            static_syslibs: "ON"
-            artifact: moxygen-linux-arm64.tar.gz
-            debug_artifact: moxygen-linux-arm64-symbols.tar.gz
-            container: ""
 
     name: publish (${{ matrix.name }})
     runs-on: ${{ matrix.runner }}
@@ -242,32 +208,10 @@ jobs:
             # Self-hosted without container: use home dir
             EXTRA_FLAGS+=(-DFETCHCONTENT_BASE_DIR="$HOME/.cache/moxygen-publish-${{ matrix.name }}/_deps")
           fi
-          # Build up combined C/CXX flags. matrix.cxx_flags is applied
-          # uniformly (any entry can request flags). matrix.static_syslibs
-          # additionally triggers the portable-tarball treatment: static-link
-          # the SONAME-churning system libs, disable libunwind (Ubuntu's
-          # libunwind.a is non-PIC, blocks PIE link), and disable LTO link-
-          # time codegen (Debian/Ubuntu fat-LTO system .a files would otherwise
-          # clash with -O3 -march + PIE producing R_AARCH64_ADR_PREL_PG_HI21
-          # against __stack_chk_guard).
-          COMBINED_FLAGS="${{ matrix.cxx_flags }}"
-          if [ "${{ matrix.static_syslibs }}" = "ON" ]; then
-            EXTRA_FLAGS+=(-DBUNDLE_DEPS_STATIC_SYSLIBS=ON)
-            EXTRA_FLAGS+=(-DCMAKE_DISABLE_FIND_PACKAGE_LibUnwind=TRUE)
-            COMBINED_FLAGS="$COMBINED_FLAGS -fno-lto"
-            EXTRA_FLAGS+=(-DCMAKE_EXE_LINKER_FLAGS="-fno-lto")
-            EXTRA_FLAGS+=(-DCMAKE_SHARED_LINKER_FLAGS="-fno-lto")
-          fi
-          if [ -n "$COMBINED_FLAGS" ]; then
-            EXTRA_FLAGS+=(-DCMAKE_C_FLAGS="$COMBINED_FLAGS")
-            EXTRA_FLAGS+=(-DCMAKE_CXX_FLAGS="$COMBINED_FLAGS")
-          fi
           cmake -B _build -S standalone -G Ninja \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-            -DBUILD_TESTS=OFF \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DBUILD_TESTING=OFF \
             -DBUILD_SHARED_LIBS=OFF \
             -DBUNDLE_DEPS=ON \

--- a/openmoq/scripts/collect-artifacts-standalone.sh
+++ b/openmoq/scripts/collect-artifacts-standalone.sh
@@ -89,18 +89,7 @@ if [[ "$OS" == "Darwin" ]]; then
     fi
     strip -S "$lib" 2>/dev/null && STRIPPED=$((STRIPPED + 1)) || true
   done < <(find "$INSTALL_PREFIX" \( -name '*.a' -o -name '*.dylib' \) -type f -print0)
-  # Executables under bin/ — same treatment.
-  if [[ -d "$INSTALL_PREFIX/bin" ]]; then
-    while IFS= read -r -d '' exe; do
-      if [[ -n "$DEBUG_DIR" ]]; then
-        REL="${exe#$INSTALL_PREFIX/}"
-        mkdir -p "$DEBUG_DIR/$(dirname "$REL")"
-        cp "$exe" "$DEBUG_DIR/${REL}.debug" 2>/dev/null || true
-      fi
-      strip -S "$exe" 2>/dev/null && STRIPPED=$((STRIPPED + 1)) || true
-    done < <(find "$INSTALL_PREFIX/bin" -type f -perm -u+x -print0)
-  fi
-  echo "    macOS: stripped $STRIPPED files"
+  echo "    macOS: stripped $STRIPPED libraries"
 
 elif [[ "$OS" == "Linux" ]]; then
   while IFS= read -r -d '' lib; do
@@ -118,25 +107,7 @@ elif [[ "$OS" == "Linux" ]]; then
       STRIPPED=$((STRIPPED + 1))
     fi
   done < <(find "$INSTALL_PREFIX" \( -name '*.a' -o -name '*.so' -o -name '*.so.*' \) -type f -print0)
-  # Executables under bin/ — same treatment as libs.
-  # Walks bin/ explicitly (executables typically have no extension, so the
-  # lib find above misses them — that's the bug fix).
-  if [[ -d "$INSTALL_PREFIX/bin" ]]; then
-    while IFS= read -r -d '' exe; do
-      if [[ -n "$DEBUG_DIR" ]]; then
-        REL="${exe#$INSTALL_PREFIX/}"
-        mkdir -p "$DEBUG_DIR/$(dirname "$REL")"
-        objcopy --only-keep-debug "$exe" "$DEBUG_DIR/${REL}.debug" 2>/dev/null || true
-      fi
-      if strip --strip-debug "$exe" 2>/dev/null; then
-        if [[ -n "$DEBUG_DIR" && -f "$DEBUG_DIR/${REL}.debug" ]]; then
-          objcopy --add-gnu-debuglink="$DEBUG_DIR/${REL}.debug" "$exe" 2>/dev/null || true
-        fi
-        STRIPPED=$((STRIPPED + 1))
-      fi
-    done < <(find "$INSTALL_PREFIX/bin" -type f -perm -u+x -print0)
-  fi
-  echo "    Linux: stripped $STRIPPED files"
+  echo "    Linux: stripped $STRIPPED libraries"
 
 else
   echo "    Warning: unknown OS '$OS', skipping strip" >&2

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -27,14 +27,6 @@ option(BUNDLE_DEPS "Build all dep targets for artifact bundling" OFF)
 option(INSTALL_DEPS "Build and install all transitive dep targets" OFF)
 option(BUILD_PICOQUIC "Build with picoquic transport support" ON)
 
-# When ON, statically link glog/gflags/double-conversion into the bundled
-# artifact. OFF (default) preserves the legacy behavior where these libs
-# stay dynamic so consumers' find_package(Glog) etc. resolve to the same
-# system .so. ON is intended for portable production tarballs that need to
-# run across Ubuntu/Debian/RHEL releases without matching SONAMEs.
-option(BUNDLE_DEPS_STATIC_SYSLIBS
-    "Static-link glog/gflags/double-conversion in BUNDLE_DEPS artifact" OFF)
-
 # =============================================================================
 # Linking preferences
 # =============================================================================
@@ -100,22 +92,17 @@ list(APPEND CMAKE_MODULE_PATH
 )
 find_package(Threads REQUIRED)
 find_package(OpenSSL REQUIRED)
-# Default (BUNDLE_DEPS_STATIC_SYSLIBS=OFF): prefer .so for these libs so
-# folly-targets.cmake hardcodes .so paths. Consumers' own find_package(Glog)
-# then resolve to the same .so — no dual-linkage under ASAN.
-# BUNDLE_DEPS_STATIC_SYSLIBS=ON: omit the override so the BUNDLE_DEPS
-# .a preference applies, statically linking glog/gflags/double-conversion
-# into the artifact for cross-distro portability.
-if(BUNDLE_DEPS AND CMAKE_SYSTEM_NAME STREQUAL "Linux"
-        AND NOT BUNDLE_DEPS_STATIC_SYSLIBS)
+# glog/gflags/double-conversion: find with .so preference so the tarball's
+# folly-targets.cmake hardcodes .so paths, not .a. Consumers that also
+# find_package(Glog) then get the same .so — no dual-linkage under ASAN.
+if(BUNDLE_DEPS AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(_saved_suffixes "${CMAKE_FIND_LIBRARY_SUFFIXES}")
     set(CMAKE_FIND_LIBRARY_SUFFIXES ".so;.a")
 endif()
 find_package(gflags CONFIG REQUIRED)
 find_package(Glog REQUIRED)
 find_package(double-conversion CONFIG REQUIRED)
-if(BUNDLE_DEPS AND CMAKE_SYSTEM_NAME STREQUAL "Linux"
-        AND NOT BUNDLE_DEPS_STATIC_SYSLIBS)
+if(BUNDLE_DEPS AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(CMAKE_FIND_LIBRARY_SUFFIXES "${_saved_suffixes}")
 endif()
 find_package(Boost 1.70 REQUIRED COMPONENTS


### PR DESCRIPTION
Reverts #184 (commit 33855900).

## Why

#184 added \`-DBUILD_TESTS=OFF\` to the publish step. Before #184 the publish ran with \`BUILD_TESTS\` defaulting ON and \`BUILD_TESTING=OFF\` — googletest was fetched + built + installed (so \`lib/cmake/GTest/GTestConfig.cmake\` landed in the tarball), but no tests ran. After #184, googletest isn't fetched at all → no \`GTestConfig.cmake\` in the new tarballs → moqx's \`test/CMakeLists.txt\` \`find_package(GTest)\` fails against \`.scratch/moxygen-install/\` (see openmoq/moqx#262).

Removing just the \`-DBUILD_TESTS=OFF\` line in isolation isn't safe — the new portable linux-{amd64,arm64} matrix entries with \`-march=...\`, \`-fno-lto\`, and \`BUNDLE_DEPS_STATIC_SYSLIBS=ON\` were validated together with that flag. Re-landing should redo the validation as a unit.

## What gets reverted

- New portable \`linux-amd64\` / \`linux-arm64\` publish matrix entries
- New debuggable Linux RelWithDebInfo entries (frame-pointer flags)
- \`BUNDLE_DEPS_STATIC_SYSLIBS\` option in standalone/CMakeLists.txt
- \`bin/\` executable strip walk in collect-artifacts-standalone.sh (this was a real bug fix — re-land separately)

## Test plan

- [ ] After merge, openmoq/moxygen publish runs and re-uploads the existing tarballs (bookworm-amd64, bookworm-arm64, ubuntu-22.04-amd64, macos-15-arm64) with \`GTestConfig.cmake\` present.
- [ ] openmoq/moqx \`sync-moxygen/<sha>\` PR auto-opens, CI green, auto-merges.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/188)
<!-- Reviewable:end -->
