### PR TITLE
hotfix: restore GTest in publish tarball (revert #184 matrix, keep bin/ strip)

### DIFF
--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -134,28 +134,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Linux RelWithDebInfo entries: keep frame pointers preserved so
-          # signal-handler stack unwinding (folly::symbolizer) and post-mortem
-          # debugging via the -dbg sidecar work reliably under -O2.
           - name: ubuntu-22.04-amd64
             runner: ubuntu-22.04
-            build_type: RelWithDebInfo
-            cxx_flags: "-fno-omit-frame-pointer -fasynchronous-unwind-tables"
             artifact: moxygen-ubuntu-22.04-amd64.tar.gz
             debug_artifact: moxygen-ubuntu-22.04-amd64-dbg.tar.gz
             container: ""
 
           - name: macos-15-arm64
             runner: macos-15
-            build_type: RelWithDebInfo
             artifact: moxygen-macos-15-arm64.tar.gz
             debug_artifact: moxygen-macos-15-arm64-dbg.tar.gz
             container: ""
 
           - name: bookworm-amd64
             runner: [self-hosted, linode]
-            build_type: RelWithDebInfo
-            cxx_flags: "-fno-omit-frame-pointer -fasynchronous-unwind-tables"
             artifact: moxygen-bookworm-amd64.tar.gz
             debug_artifact: moxygen-bookworm-amd64-dbg.tar.gz
             container: debian:bookworm
@@ -163,35 +155,9 @@ jobs:
 
           - name: bookworm-arm64
             runner: ubuntu-22.04-arm
-            build_type: RelWithDebInfo
-            cxx_flags: "-fno-omit-frame-pointer -fasynchronous-unwind-tables"
             artifact: moxygen-bookworm-arm64.tar.gz
             debug_artifact: moxygen-bookworm-arm64-dbg.tar.gz
             container: debian:bookworm
-
-          # ── Portable Linux production tarballs ──
-          # Release build on jammy base, statically linked for cross-distro
-          # compatibility. cxx_flags pin the ISA baseline:
-          #   x86-64-v2 = SSE4.2+POPCNT (≈ all cloud x86 since 2015)
-          #   armv8-a   = base ARMv8.0 (covers Graviton 1-4, Ampere, Apple M,
-          #               RPi 3/4/5, Rockchip RK3399 + RK3588 / Orange Pi)
-          - name: linux-amd64
-            runner: ubuntu-22.04
-            build_type: Release
-            cxx_flags: "-march=x86-64-v2"
-            static_syslibs: "ON"
-            artifact: moxygen-linux-amd64.tar.gz
-            debug_artifact: moxygen-linux-amd64-symbols.tar.gz
-            container: ""
-
-          - name: linux-arm64
-            runner: ubuntu-22.04-arm
-            build_type: Release
-            cxx_flags: "-march=armv8-a"
-            static_syslibs: "ON"
-            artifact: moxygen-linux-arm64.tar.gz
-            debug_artifact: moxygen-linux-arm64-symbols.tar.gz
-            container: ""
 
     name: publish (${{ matrix.name }})
     runs-on: ${{ matrix.runner }}
@@ -242,32 +208,10 @@ jobs:
             # Self-hosted without container: use home dir
             EXTRA_FLAGS+=(-DFETCHCONTENT_BASE_DIR="$HOME/.cache/moxygen-publish-${{ matrix.name }}/_deps")
           fi
-          # Build up combined C/CXX flags. matrix.cxx_flags is applied
-          # uniformly (any entry can request flags). matrix.static_syslibs
-          # additionally triggers the portable-tarball treatment: static-link
-          # the SONAME-churning system libs, disable libunwind (Ubuntu's
-          # libunwind.a is non-PIC, blocks PIE link), and disable LTO link-
-          # time codegen (Debian/Ubuntu fat-LTO system .a files would otherwise
-          # clash with -O3 -march + PIE producing R_AARCH64_ADR_PREL_PG_HI21
-          # against __stack_chk_guard).
-          COMBINED_FLAGS="${{ matrix.cxx_flags }}"
-          if [ "${{ matrix.static_syslibs }}" = "ON" ]; then
-            EXTRA_FLAGS+=(-DBUNDLE_DEPS_STATIC_SYSLIBS=ON)
-            EXTRA_FLAGS+=(-DCMAKE_DISABLE_FIND_PACKAGE_LibUnwind=TRUE)
-            COMBINED_FLAGS="$COMBINED_FLAGS -fno-lto"
-            EXTRA_FLAGS+=(-DCMAKE_EXE_LINKER_FLAGS="-fno-lto")
-            EXTRA_FLAGS+=(-DCMAKE_SHARED_LINKER_FLAGS="-fno-lto")
-          fi
-          if [ -n "$COMBINED_FLAGS" ]; then
-            EXTRA_FLAGS+=(-DCMAKE_C_FLAGS="$COMBINED_FLAGS")
-            EXTRA_FLAGS+=(-DCMAKE_CXX_FLAGS="$COMBINED_FLAGS")
-          fi
           cmake -B _build -S standalone -G Ninja \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-            -DBUILD_TESTS=OFF \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DBUILD_TESTING=OFF \
             -DBUILD_SHARED_LIBS=OFF \
             -DBUNDLE_DEPS=ON \

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -27,14 +27,6 @@ option(BUNDLE_DEPS "Build all dep targets for artifact bundling" OFF)
 option(INSTALL_DEPS "Build and install all transitive dep targets" OFF)
 option(BUILD_PICOQUIC "Build with picoquic transport support" ON)
 
-# When ON, statically link glog/gflags/double-conversion into the bundled
-# artifact. OFF (default) preserves the legacy behavior where these libs
-# stay dynamic so consumers' find_package(Glog) etc. resolve to the same
-# system .so. ON is intended for portable production tarballs that need to
-# run across Ubuntu/Debian/RHEL releases without matching SONAMEs.
-option(BUNDLE_DEPS_STATIC_SYSLIBS
-    "Static-link glog/gflags/double-conversion in BUNDLE_DEPS artifact" OFF)
-
 # =============================================================================
 # Linking preferences
 # =============================================================================
@@ -100,22 +92,17 @@ list(APPEND CMAKE_MODULE_PATH
 )
 find_package(Threads REQUIRED)
 find_package(OpenSSL REQUIRED)
-# Default (BUNDLE_DEPS_STATIC_SYSLIBS=OFF): prefer .so for these libs so
-# folly-targets.cmake hardcodes .so paths. Consumers' own find_package(Glog)
-# then resolve to the same .so — no dual-linkage under ASAN.
-# BUNDLE_DEPS_STATIC_SYSLIBS=ON: omit the override so the BUNDLE_DEPS
-# .a preference applies, statically linking glog/gflags/double-conversion
-# into the artifact for cross-distro portability.
-if(BUNDLE_DEPS AND CMAKE_SYSTEM_NAME STREQUAL "Linux"
-        AND NOT BUNDLE_DEPS_STATIC_SYSLIBS)
+# glog/gflags/double-conversion: find with .so preference so the tarball's
+# folly-targets.cmake hardcodes .so paths, not .a. Consumers that also
+# find_package(Glog) then get the same .so — no dual-linkage under ASAN.
+if(BUNDLE_DEPS AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(_saved_suffixes "${CMAKE_FIND_LIBRARY_SUFFIXES}")
     set(CMAKE_FIND_LIBRARY_SUFFIXES ".so;.a")
 endif()
 find_package(gflags CONFIG REQUIRED)
 find_package(Glog REQUIRED)
 find_package(double-conversion CONFIG REQUIRED)
-if(BUNDLE_DEPS AND CMAKE_SYSTEM_NAME STREQUAL "Linux"
-        AND NOT BUNDLE_DEPS_STATIC_SYSLIBS)
+if(BUNDLE_DEPS AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(CMAKE_FIND_LIBRARY_SUFFIXES "${_saved_suffixes}")
 endif()
 find_package(Boost 1.70 REQUIRED COMPONENTS


### PR DESCRIPTION
Targeted revert of #184 to fix openmoq/moqx#262.

## Problem

#184 added \`-DBUILD_TESTS=OFF\` to the publish step. Pre-#184 the publish ran with \`BUILD_TESTS\` defaulting ON and \`BUILD_TESTING=OFF\` — googletest was fetched + built + installed (so \`lib/cmake/GTest/GTestConfig.cmake\` landed in the tarball), but no tests ran. Post-#184, googletest isn't fetched → \`GTestConfig.cmake\` missing → moqx \`test/CMakeLists.txt\` \`find_package(GTest)\` fails against \`.scratch/moxygen-install/\` (moqx#262).

The new portable \`linux-{amd64,arm64}\` matrix with \`-march=...\`, \`-fno-lto\`, \`BUNDLE_DEPS_STATIC_SYSLIBS=ON\` was validated together with \`BUILD_TESTS=OFF\`, so removing the flag in isolation isn't safe.

## What this PR reverts (from #184)

- New portable \`linux-amd64\` / \`linux-arm64\` publish matrix entries
- Debuggable RelWithDebInfo flag-handling block in publish
- \`-DBUILD_TESTS=OFF\` in the publish cmake configure
- \`BUNDLE_DEPS_STATIC_SYSLIBS\` option in \`standalone/CMakeLists.txt\`

## What this PR keeps (from #184)

- \`bin/\` executable strip walk in \`openmoq/scripts/collect-artifacts-standalone.sh\` — a real bug fix unrelated to the matrix work (executables under \`bin/\` have no extension, so the prior \`*.a/*.so/*.dylib\` find missed them).

## Follow-on

Re-land the portable tarball logic as a separate \`workflow_dispatch\`-only release workflow that doesn't touch the rolling \`snapshot-latest\` path. Tracked separately.

## Test plan

- [ ] After merge, openmoq/moxygen publish runs and re-uploads bookworm-amd64, bookworm-arm64, ubuntu-22.04-amd64, macos-15-arm64 with \`GTestConfig.cmake\` present in \`lib/cmake/GTest/\`.
- [ ] openmoq/moqx \`sync-moxygen/<sha>\` PR auto-opens and CI is green (find_package(GTest) succeeds).
- [ ] Confirm the bin/ strip walk still runs in publish (look for \`stripped <N> files\` in the publish job log, where N includes both lib and bin counts).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/189)
<!-- Reviewable:end -->
