### PR TITLE
hotfix: use namespaced picoquic::picoquic-log in LINK_GROUP

### DIFF
--- a/build/deps/github_hashes/openmoq/picoquic-rev.txt
+++ b/build/deps/github_hashes/openmoq/picoquic-rev.txt
@@ -1,1 +1,1 @@
-Subproject commit cb0aac6a11bdd5a449166e036ce3bc120f94b9c9
+Subproject commit 80d379e04b29dcacea96ccaa5c3a19f9a5c8e06c

--- a/moxygen/openmoq/transport/pico/CMakeLists.txt
+++ b/moxygen/openmoq/transport/pico/CMakeLists.txt
@@ -21,12 +21,12 @@ moxygen_add_library(openmoq_pico_base
 # dedupe-safe). ld64 (macOS) rescans by default.
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   target_link_libraries(openmoq_pico_base PUBLIC
-    "$<LINK_GROUP:RESCAN,picoquic::picoquic-core,picoquic-log>"
+    "$<LINK_GROUP:RESCAN,picoquic::picoquic-core,picoquic::picoquic-log>"
   )
 else()
   target_link_libraries(openmoq_pico_base PUBLIC
     picoquic::picoquic-core
-    picoquic-log
+    picoquic::picoquic-log
   )
 endif()
 # PicoConnectionContext.h includes PicoH3WebTransport.h which needs h3zero.


### PR DESCRIPTION
## Summary
Two-part hotfix to unblock downstream linking after #187:

1. **Bump picoquic** to `80d379e` (openmoq/picoquic#<TBD: link the alias PR>) which adds the missing `add_library(picoquic::picoquic-log ALIAS picoquic-log)`. Picoquic already had aliases for `picoquic-core` and `picohttp-core`; `picoquic-log` was a gap.

2. **Use namespaced `picoquic::picoquic-log`** in [`moxygen/openmoq/transport/pico/CMakeLists.txt`](moxygen/openmoq/transport/pico/CMakeLists.txt) (both Linux LINK_GROUP and non-Linux paths). The bare name was emitted as `-lpicoquic-log` in moxygen's exported `INTERFACE_LINK_LIBRARIES`, breaking downstream link in moqx (which has no `-L` for the moxygen install lib dir).

## Symptom (pre-fix)
Every moqx PR after moxygen snapshot republished with #187:
\`\`\`
/usr/bin/ld: cannot find -lpicoquic-log: No such file or directory
\`\`\`
- https://github.com/openmoq/moqx/actions/runs/25257557501
- https://github.com/openmoq/moqx/actions/runs/25257564546

## Local validation
Built moxygen standalone end-to-end on Linux (Ubuntu 22.04):
- `cmake -S standalone -B _build_validate -G Ninja` configures cleanly (no "target not found")
- `cmake --build _build_validate --target pico_relay_server` links the executable
- `nm pico_relay_server | grep picoquic_set_qlog` → resolved as `T` (defined)
- `ldd pico_relay_server` → no missing libs

## Test plan
- [x] Local standalone build links pico_relay_server
- [ ] Moxygen CI green on this branch
- [ ] After merge: next moqx PR CI run links successfully against republished snapshot-latest
- [ ] Auto-bump workflow tracks future picoquic main updates

## Dependent PRs
- openmoq/picoquic#<TBD> — the alias addition (must merge first or bundled into a single picoquic SHA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/191)
<!-- Reviewable:end -->
