### PR TITLE
release: build portable linux tarballs as part of version release

### DIFF
--- a/.github/workflows/omoq-version-release.yml
+++ b/.github/workflows/omoq-version-release.yml
@@ -1,8 +1,10 @@
 name: version release
 
-# Manual workflow to promote snapshot-latest artifacts to a versioned release.
-# Downloads tarballs from the current snapshot-latest pre-release and creates
-# a tagged, non-prerelease GitHub release.
+# Manual workflow to cut a versioned release from the current main.
+# Builds portable Linux production tarballs (-O3 + frame pointers + static
+# system libs, ISA-baselined for cross-distro portability) on demand, then
+# combines them with the existing platform tarballs promoted from
+# `snapshot-latest`, and creates a tagged, non-prerelease GitHub release.
 #
 # Usage: Actions → version release → Run workflow → enter version (e.g. 1.2.3)
 
@@ -18,12 +20,20 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  # ════════════════════════════════════════════════════════════════════════════
+  # Validate: gate on semver + non-existing tag before doing any expensive work
+  # ════════════════════════════════════════════════════════════════════════════
+
+  validate:
     runs-on: ubuntu-22.04
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      tag: ${{ steps.v.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Validate version
+        id: v
         run: |
           VERSION="${{ inputs.version }}"
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
@@ -35,18 +45,147 @@ jobs:
             echo "Error: tag $TAG already exists" >&2
             exit 1
           fi
-          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
-          echo "TAG=$TAG" >> "$GITHUB_ENV"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+  # ════════════════════════════════════════════════════════════════════════════
+  # Portable-build: -O3 + frame-pointer + static-syslibs Linux tarballs.
+  # Built from the workflow's checkout (HEAD of main); produces the artifacts
+  # consumed by moqx release flows for portable production deployment.
+  # ════════════════════════════════════════════════════════════════════════════
+
+  portable-build:
+    needs: [validate]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # ISA baseline pins:
+          #   x86-64-v2 = SSE4.2+POPCNT (≈ all cloud x86 since 2015)
+          #   armv8-a   = base ARMv8.0 (covers Graviton 1-4, Ampere, Apple M,
+          #               RPi 3/4/5, Rockchip RK3399 + RK3588 / Orange Pi)
+          - name: linux-amd64
+            runner: ubuntu-22.04
+            cxx_flags: "-march=x86-64-v2 -fno-omit-frame-pointer -fasynchronous-unwind-tables"
+            artifact: moxygen-linux-amd64.tar.gz
+            debug_artifact: moxygen-linux-amd64-symbols.tar.gz
+
+          - name: linux-arm64
+            runner: ubuntu-22.04-arm
+            cxx_flags: "-march=armv8-a -fno-omit-frame-pointer -fasynchronous-unwind-tables"
+            artifact: moxygen-linux-arm64.tar.gz
+            debug_artifact: moxygen-linux-arm64-symbols.tar.gz
+
+    name: portable (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: bash standalone/install-system-deps.sh
+
+      - name: Cache FetchContent downloads
+        uses: actions/cache@v4
+        with:
+          path: _build/_deps
+          key: portable-${{ matrix.name }}-deps-${{ hashFiles('build/deps/github_hashes/**/*-rev.txt', 'standalone/patches/**') }}
+          restore-keys: |
+            portable-${{ matrix.name }}-deps-
+
+      - name: Set up ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: portable-${{ matrix.name }}
+          max-size: 500M
+
+      - name: Configure
+        shell: bash
+        run: |
+          # Portable tarball treatment: static-link the SONAME-churning system
+          # libs (glog/gflags/double-conversion), disable libunwind (Ubuntu's
+          # libunwind.a is non-PIC, blocks PIE link), and disable LTO link-
+          # time codegen (Debian/Ubuntu fat-LTO system .a files would otherwise
+          # clash with -O3 -march + PIE producing R_AARCH64_ADR_PREL_PG_HI21
+          # against __stack_chk_guard).
+          #
+          # BUILD_TESTS=ON intentional: the moxygen tarball ships
+          # lib/cmake/GTest/GTestConfig.cmake which moqx's test/CMakeLists.txt
+          # consumes. No tests run because BUILD_TESTING=OFF.
+          cmake -B _build -S standalone -G Ninja \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -DBUILD_TESTS=ON \
+            -DBUILD_TESTING=OFF \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DBUNDLE_DEPS=ON \
+            -DBUNDLE_DEPS_STATIC_SYSLIBS=ON \
+            -DCMAKE_DISABLE_FIND_PACKAGE_LibUnwind=TRUE \
+            -DCMAKE_C_FLAGS="${{ matrix.cxx_flags }} -fno-lto" \
+            -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }} -fno-lto" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fno-lto" \
+            -DCMAKE_SHARED_LINKER_FLAGS="-fno-lto" \
+            -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/install"
+
+      - name: Build
+        run: cmake --build _build -j$(getconf _NPROCESSORS_ONLN)
+
+      - name: Install
+        run: cmake --install _build
+
+      - name: Package
+        run: |
+          bash openmoq/scripts/collect-artifacts-standalone.sh \
+            --install-prefix "$GITHUB_WORKSPACE/install" \
+            --output "${{ matrix.artifact }}" \
+            --debug-output "${{ matrix.debug_artifact }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+          retention-days: 90
+
+      - name: Upload debug artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.debug_artifact }}
+          path: ${{ matrix.debug_artifact }}
+          retention-days: 90
+
+  # ════════════════════════════════════════════════════════════════════════════
+  # Release: combine portable tarballs with promoted snapshot tarballs and
+  # create the tagged, non-prerelease GitHub release.
+  # ════════════════════════════════════════════════════════════════════════════
+
+  release:
+    needs: [validate, portable-build]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download portable artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: portable-assets/
+          merge-multiple: true
 
       - name: Download snapshot artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mkdir -p release-assets
-          echo "Downloading artifacts from snapshot-latest..."
-          gh release download snapshot-latest --dir release-assets --pattern '*.tar.gz'
-          echo "Downloaded:"
-          ls -lh release-assets/
+          mkdir -p snapshot-assets
+          echo "Downloading existing platform tarballs from snapshot-latest..."
+          gh release download snapshot-latest --dir snapshot-assets --pattern '*.tar.gz'
+          # Don't bring portable tarballs over from snapshot — we just built
+          # fresh ones in this workflow.
+          rm -f snapshot-assets/moxygen-linux-amd64*.tar.gz \
+                snapshot-assets/moxygen-linux-arm64*.tar.gz
+          echo "Snapshot platform tarballs:"
+          ls -lh snapshot-assets/
 
       - name: Get snapshot commit
         env:
@@ -61,9 +200,19 @@ jobs:
           echo "Snapshot built from commit: $SNAPSHOT_SHA"
           echo "SNAPSHOT_SHA=$SNAPSHOT_SHA" >> "$GITHUB_ENV"
 
+      - name: Stage release assets
+        run: |
+          mkdir -p release-assets
+          cp snapshot-assets/*.tar.gz release-assets/
+          cp portable-assets/*.tar.gz release-assets/
+          echo "Release assets:"
+          ls -lh release-assets/
+
       - name: Create versioned release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.validate.outputs.version }}
+          TAG: ${{ needs.validate.outputs.tag }}
         run: |
           echo "Creating release $TAG from snapshot commit $SNAPSHOT_SHA..."
           gh release create "$TAG" release-assets/*.tar.gz \
@@ -73,11 +222,18 @@ jobs:
           **Version:** \`${VERSION}\`
           **Commit:** \`${SNAPSHOT_SHA}\`
 
-          Promoted from [\`snapshot-latest\`](${{ github.server_url }}/${{ github.repository }}/releases/tag/snapshot-latest).
+          Existing platform tarballs promoted from [\`snapshot-latest\`](${{ github.server_url }}/${{ github.repository }}/releases/tag/snapshot-latest); portable Linux tarballs built fresh from this commit.
 
-          Each platform has two tarballs:
+          **Existing platform tarballs** (RelWithDebInfo, distro-specific):
           - \`moxygen-<platform>.tar.gz\` — stripped release build
-          - \`moxygen-<platform>-dbg.tar.gz\` — split debug symbols
+          - \`moxygen-<platform>-dbg.tar.gz\` — split debug symbols (.debug sidecar)
+
+          **Portable Linux tarballs** (Release -O3, ISA-baselined, statically linked):
+          - \`moxygen-linux-amd64.tar.gz\` — \`-march=x86-64-v2\` (≈ all cloud x86 since 2015)
+          - \`moxygen-linux-arm64.tar.gz\` — \`-march=armv8-a\` (Graviton, Ampere, Apple M, RPi 3+, Rockchip)
+          - \`moxygen-linux-{amd64,arm64}-symbols.tar.gz\` — split debug symbols (.debug sidecar)
+
+          Portable tarballs are compiled with frame pointers preserved (\`-fno-omit-frame-pointer -fasynchronous-unwind-tables\`) so signal-handler stack unwinding (folly::symbolizer) works against the .symbols sidecar even at \`-O3\`.
           EOF
           )"
           echo "Released: $TAG"

--- a/.github/workflows/omoq-version-release.yml
+++ b/.github/workflows/omoq-version-release.yml
@@ -1,10 +1,29 @@
 name: version release
 
-# Manual workflow to cut a versioned release from the current main.
+# Manual workflow to cut a versioned release from the dispatched ref.
 # Builds portable Linux production tarballs (-O3 + frame pointers + static
-# system libs, ISA-baselined for cross-distro portability) on demand, then
-# combines them with the existing platform tarballs promoted from
-# `snapshot-latest`, and creates a tagged, non-prerelease GitHub release.
+# system libs, ISA-baselined for cross-distro portability) on demand,
+# combines them with the existing platform tarballs promoted from the
+# rolling snapshot pre-release, and creates a tagged, non-prerelease
+# GitHub release.
+#
+# Job graph (parallel):
+#
+#   validate
+#     │
+#     ▼
+#   create-release (--draft)
+#     │
+#     ├──► portable-build (matrix amd64/arm64) ─► uploads directly to release
+#     ├──► promote-snapshot ─► xargs -P parallel uploads to release
+#     │
+#     ▼
+#   finalize (--draft=false)
+#
+# Direct uploads from build runners avoid the actions/upload-artifact +
+# actions/download-artifact round-trip; parallel xargs in promote-snapshot
+# fans out the 8 platform tarballs concurrently. Combined: ~30 min wall
+# clock vs the ~2 hours a serial create+upload would take.
 #
 # Usage: Actions → version release → Run workflow → enter version (e.g. 1.2.3)
 
@@ -21,7 +40,8 @@ permissions:
 
 jobs:
   # ════════════════════════════════════════════════════════════════════════════
-  # Validate: gate on semver + non-existing tag before doing any expensive work
+  # Validate: gate on semver + tag-doesn't-exist + resolve snapshot tag/sha
+  # before doing any expensive work.
   # ════════════════════════════════════════════════════════════════════════════
 
   validate:
@@ -30,14 +50,17 @@ jobs:
       version: ${{ steps.v.outputs.version }}
       tag: ${{ steps.v.outputs.tag }}
       snapshot_tag: ${{ steps.v.outputs.snapshot_tag }}
+      snapshot_sha: ${{ steps.v.outputs.snapshot_sha }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Validate version
+      - name: Validate inputs and resolve refs
         id: v
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ inputs.version }}"
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
             echo "Error: version must be semver (e.g. 1.2.3 or 1.2.3-rc1)" >&2
             exit 1
           fi
@@ -46,9 +69,8 @@ jobs:
             echo "Error: tag $TAG already exists" >&2
             exit 1
           fi
-          # Resolve which rolling snapshot to consume based on the dispatched
-          # ref. main → snapshot-latest. release/vM.m → snapshot-vM.m-latest.
-          # Mirrors omoq-ci-main.yml's release-tag computation.
+
+          # Snapshot derived from dispatched ref.
           BRANCH="${{ github.ref_name }}"
           if [ "$BRANCH" = "main" ]; then
             SNAPSHOT_TAG="snapshot-latest"
@@ -56,19 +78,74 @@ jobs:
             LABEL="${BRANCH#release/}"
             SNAPSHOT_TAG="snapshot-${LABEL}-latest"
           fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "snapshot_tag=$SNAPSHOT_TAG" >> "$GITHUB_OUTPUT"
-          echo "Dispatched from: $BRANCH → snapshot tag: $SNAPSHOT_TAG"
+
+          # Resolve snapshot SHA (the commit ci-main built from).
+          SNAPSHOT_SHA=$(gh api repos/{owner}/{repo}/releases \
+            --jq ".[] | select(.tag_name == \"$SNAPSHOT_TAG\") | .target_commitish")
+          if [[ -z "$SNAPSHOT_SHA" ]]; then
+            echo "Error: $SNAPSHOT_TAG release not found. Push to the dispatched branch first to produce a snapshot." >&2
+            exit 1
+          fi
+
+          {
+            echo "version=$VERSION"
+            echo "tag=$TAG"
+            echo "snapshot_tag=$SNAPSHOT_TAG"
+            echo "snapshot_sha=$SNAPSHOT_SHA"
+          } >> "$GITHUB_OUTPUT"
+          echo "Dispatched from $BRANCH → snapshot $SNAPSHOT_TAG @ $SNAPSHOT_SHA"
+
+  # ════════════════════════════════════════════════════════════════════════════
+  # Create-release: open a draft release that the upload jobs append to.
+  # Asset uploads happen in portable-build and promote-snapshot, both running
+  # in parallel and pushing directly to this release.
+  # ════════════════════════════════════════════════════════════════════════════
+
+  create-release:
+    needs: [validate]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.validate.outputs.version }}
+          TAG: ${{ needs.validate.outputs.tag }}
+          SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
+          SNAPSHOT_SHA: ${{ needs.validate.outputs.snapshot_sha }}
+        run: |
+          gh release create "$TAG" \
+            --target "$SNAPSHOT_SHA" \
+            --title "moxygen $VERSION" \
+            --draft \
+            --notes "$(cat <<EOF
+          **Version:** \`${VERSION}\`
+          **Commit:** \`${SNAPSHOT_SHA}\`
+
+          Existing platform tarballs promoted from [\`${SNAPSHOT_TAG}\`](${{ github.server_url }}/${{ github.repository }}/releases/tag/${SNAPSHOT_TAG}); portable Linux tarballs built fresh from this commit.
+
+          **Existing platform tarballs** (RelWithDebInfo, distro-specific):
+          - \`moxygen-<platform>.tar.gz\` — stripped release build
+          - \`moxygen-<platform>-dbg.tar.gz\` — split debug symbols (.debug sidecar)
+
+          **Portable Linux tarballs** (Release -O3, ISA-baselined, statically linked):
+          - \`moxygen-linux-amd64.tar.gz\` — \`-march=x86-64-v2\` (≈ all cloud x86 since 2015)
+          - \`moxygen-linux-arm64.tar.gz\` — \`-march=armv8-a\` (Graviton, Ampere, Apple M, RPi 3+, Rockchip)
+          - \`moxygen-linux-{amd64,arm64}-dbg.tar.gz\` — split debug symbols (.debug sidecar)
+
+          Portable tarballs are compiled with frame pointers preserved (\`-fno-omit-frame-pointer -fasynchronous-unwind-tables\`) so signal-handler stack unwinding (folly::symbolizer) works against the .dbg sidecar even at \`-O3\`.
+          EOF
+          )"
 
   # ════════════════════════════════════════════════════════════════════════════
   # Portable-build: -O3 + frame-pointer + static-syslibs Linux tarballs.
-  # Built from the workflow's checkout (HEAD of main); produces the artifacts
-  # consumed by moqx release flows for portable production deployment.
+  # Each matrix entry uploads its own outputs directly to the draft release —
+  # avoids the actions/upload-artifact + actions/download-artifact round-trip.
   # ════════════════════════════════════════════════════════════════════════════
 
   portable-build:
-    needs: [validate]
+    needs: [validate, create-release]
     strategy:
       fail-fast: false
       matrix:
@@ -154,101 +231,67 @@ jobs:
             --install-prefix "$GITHUB_WORKSPACE/install" \
             --output "${{ matrix.artifact }}" \
             --debug-output "${{ matrix.debug_artifact }}"
+          ls -lh "${{ matrix.artifact }}" "${{ matrix.debug_artifact }}"
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.artifact }}
-          path: ${{ matrix.artifact }}
-          retention-days: 90
-
-      - name: Upload debug artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.debug_artifact }}
-          path: ${{ matrix.debug_artifact }}
-          retention-days: 90
+      - name: Upload to release (binary + dbg in parallel)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          # Upload binary and dbg sidecar in parallel from this runner.
+          # All matrix entries run on different runners so the two arches
+          # also upload concurrently with each other.
+          printf '%s\n' "${{ matrix.artifact }}" "${{ matrix.debug_artifact }}" | \
+            xargs -n1 -P 2 -I{} gh release upload "$TAG" {} --clobber
 
   # ════════════════════════════════════════════════════════════════════════════
-  # Release: combine portable tarballs with promoted snapshot tarballs and
-  # create the tagged, non-prerelease GitHub release.
+  # Promote-snapshot: copy the existing platform tarballs (bookworm/ubuntu/
+  # macos) from the rolling snapshot to the new release. Runs in parallel
+  # with portable-build; uploads via xargs -P for further fan-out.
   # ════════════════════════════════════════════════════════════════════════════
 
-  release:
-    needs: [validate, portable-build]
+  promote-snapshot:
+    needs: [validate, create-release]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Download portable artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: portable-assets/
-          merge-multiple: true
-
-      - name: Download snapshot artifacts
+      - name: Download snapshot tarballs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
         run: |
           mkdir -p snapshot-assets
-          echo "Downloading existing platform tarballs from $SNAPSHOT_TAG..."
           gh release download "$SNAPSHOT_TAG" --dir snapshot-assets --pattern '*.tar.gz'
-          # Don't bring portable tarballs over from snapshot — we just built
-          # fresh ones in this workflow.
+          # Drop any portable tarballs from snapshot — those are built fresh
+          # in portable-build and uploaded directly there.
           rm -f snapshot-assets/moxygen-linux-amd64*.tar.gz \
                 snapshot-assets/moxygen-linux-arm64*.tar.gz
-          echo "Snapshot platform tarballs:"
+          echo "Snapshot tarballs to promote:"
           ls -lh snapshot-assets/
 
-      - name: Get snapshot commit
+      - name: Upload to release (parallel)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
-        run: |
-          SNAPSHOT_SHA=$(gh api repos/{owner}/{repo}/releases \
-            --jq ".[] | select(.tag_name == \"$SNAPSHOT_TAG\") | .target_commitish")
-          if [[ -z "$SNAPSHOT_SHA" ]]; then
-            echo "Error: $SNAPSHOT_TAG release not found. Push to the dispatched branch first to produce a snapshot." >&2
-            exit 1
-          fi
-          echo "Snapshot built from commit: $SNAPSHOT_SHA"
-          echo "SNAPSHOT_SHA=$SNAPSHOT_SHA" >> "$GITHUB_ENV"
-
-      - name: Stage release assets
-        run: |
-          mkdir -p release-assets
-          cp snapshot-assets/*.tar.gz release-assets/
-          cp portable-assets/*.tar.gz release-assets/
-          echo "Release assets:"
-          ls -lh release-assets/
-
-      - name: Create versioned release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ needs.validate.outputs.version }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
-          echo "Creating release $TAG from snapshot commit $SNAPSHOT_SHA..."
-          gh release create "$TAG" release-assets/*.tar.gz \
-            --target "$SNAPSHOT_SHA" \
-            --title "moxygen $VERSION" \
-            --notes "$(cat <<EOF
-          **Version:** \`${VERSION}\`
-          **Commit:** \`${SNAPSHOT_SHA}\`
+          # Fan out asset upload to N concurrent gh release upload calls.
+          # 6 is a safe upper bound — GitHub releases handle concurrent
+          # uploads to the same release fine.
+          find snapshot-assets -name '*.tar.gz' -print0 | \
+            xargs -0 -n1 -P 6 -I{} gh release upload "$TAG" {} --clobber
 
-          Existing platform tarballs promoted from [\`${{ needs.validate.outputs.snapshot_tag }}\`](${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.validate.outputs.snapshot_tag }}); portable Linux tarballs built fresh from this commit.
+  # ════════════════════════════════════════════════════════════════════════════
+  # Finalize: flip draft → published once all assets are up. Runs only if
+  # both upload jobs succeeded.
+  # ════════════════════════════════════════════════════════════════════════════
 
-          **Existing platform tarballs** (RelWithDebInfo, distro-specific):
-          - \`moxygen-<platform>.tar.gz\` — stripped release build
-          - \`moxygen-<platform>-dbg.tar.gz\` — split debug symbols (.debug sidecar)
-
-          **Portable Linux tarballs** (Release -O3, ISA-baselined, statically linked):
-          - \`moxygen-linux-amd64.tar.gz\` — \`-march=x86-64-v2\` (≈ all cloud x86 since 2015)
-          - \`moxygen-linux-arm64.tar.gz\` — \`-march=armv8-a\` (Graviton, Ampere, Apple M, RPi 3+, Rockchip)
-          - \`moxygen-linux-{amd64,arm64}-dbg.tar.gz\` — split debug symbols (.debug sidecar)
-
-          Portable tarballs are compiled with frame pointers preserved (\`-fno-omit-frame-pointer -fasynchronous-unwind-tables\`) so signal-handler stack unwinding (folly::symbolizer) works against the .dbg sidecar even at \`-O3\`.
-          EOF
-          )"
+  finalize:
+    needs: [validate, portable-build, promote-snapshot]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          gh release edit "$TAG" --draft=false
           echo "Released: $TAG"

--- a/.github/workflows/omoq-version-release.yml
+++ b/.github/workflows/omoq-version-release.yml
@@ -277,10 +277,11 @@ jobs:
       - name: Download snapshot tarballs
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
           SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
         run: |
           mkdir -p snapshot-assets
-          gh release download "$SNAPSHOT_TAG" --dir snapshot-assets --pattern '*.tar.gz'
+          gh release download "$SNAPSHOT_TAG" --repo "$REPO" --dir snapshot-assets --pattern '*.tar.gz'
           # Drop any portable tarballs from snapshot — those are built fresh
           # in portable-build and uploaded directly there.
           rm -f snapshot-assets/moxygen-linux-amd64*.tar.gz \
@@ -291,13 +292,14 @@ jobs:
       - name: Upload to release (parallel)
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
           # Fan out asset upload to N concurrent gh release upload calls.
           # 6 is a safe upper bound — GitHub releases handle concurrent
           # uploads to the same release fine.
           find snapshot-assets -name '*.tar.gz' -print0 | \
-            xargs -0 -n1 -P 6 -I{} gh release upload "$TAG" {} --clobber
+            xargs -0 -n1 -P 6 -I{} gh release upload "$TAG" --repo "$REPO" {} --clobber
 
   # ════════════════════════════════════════════════════════════════════════════
   # Finalize: flip draft → published once all assets are up. Runs only if
@@ -318,10 +320,11 @@ jobs:
       - name: Mark release as latest
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
           # gh release create without --draft already creates a published
           # release; this step is here so we can flip latest=true after
           # all assets are up.
-          gh release edit "$TAG" --latest
+          gh release edit "$TAG" --repo "$REPO" --latest
           echo "Released: $TAG"

--- a/.github/workflows/omoq-version-release.yml
+++ b/.github/workflows/omoq-version-release.yml
@@ -29,6 +29,7 @@ jobs:
     outputs:
       version: ${{ steps.v.outputs.version }}
       tag: ${{ steps.v.outputs.tag }}
+      snapshot_tag: ${{ steps.v.outputs.snapshot_tag }}
     steps:
       - uses: actions/checkout@v4
 
@@ -45,8 +46,20 @@ jobs:
             echo "Error: tag $TAG already exists" >&2
             exit 1
           fi
+          # Resolve which rolling snapshot to consume based on the dispatched
+          # ref. main → snapshot-latest. release/vM.m → snapshot-vM.m-latest.
+          # Mirrors omoq-ci-main.yml's release-tag computation.
+          BRANCH="${{ github.ref_name }}"
+          if [ "$BRANCH" = "main" ]; then
+            SNAPSHOT_TAG="snapshot-latest"
+          else
+            LABEL="${BRANCH#release/}"
+            SNAPSHOT_TAG="snapshot-${LABEL}-latest"
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "snapshot_tag=$SNAPSHOT_TAG" >> "$GITHUB_OUTPUT"
+          echo "Dispatched from: $BRANCH → snapshot tag: $SNAPSHOT_TAG"
 
   # ════════════════════════════════════════════════════════════════════════════
   # Portable-build: -O3 + frame-pointer + static-syslibs Linux tarballs.
@@ -176,10 +189,11 @@ jobs:
       - name: Download snapshot artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
         run: |
           mkdir -p snapshot-assets
-          echo "Downloading existing platform tarballs from snapshot-latest..."
-          gh release download snapshot-latest --dir snapshot-assets --pattern '*.tar.gz'
+          echo "Downloading existing platform tarballs from $SNAPSHOT_TAG..."
+          gh release download "$SNAPSHOT_TAG" --dir snapshot-assets --pattern '*.tar.gz'
           # Don't bring portable tarballs over from snapshot — we just built
           # fresh ones in this workflow.
           rm -f snapshot-assets/moxygen-linux-amd64*.tar.gz \
@@ -190,11 +204,12 @@ jobs:
       - name: Get snapshot commit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
         run: |
           SNAPSHOT_SHA=$(gh api repos/{owner}/{repo}/releases \
-            --jq '.[] | select(.tag_name == "snapshot-latest") | .target_commitish')
+            --jq ".[] | select(.tag_name == \"$SNAPSHOT_TAG\") | .target_commitish")
           if [[ -z "$SNAPSHOT_SHA" ]]; then
-            echo "Error: snapshot-latest release not found. Run the main pipeline first." >&2
+            echo "Error: $SNAPSHOT_TAG release not found. Push to the dispatched branch first to produce a snapshot." >&2
             exit 1
           fi
           echo "Snapshot built from commit: $SNAPSHOT_SHA"
@@ -222,7 +237,7 @@ jobs:
           **Version:** \`${VERSION}\`
           **Commit:** \`${SNAPSHOT_SHA}\`
 
-          Existing platform tarballs promoted from [\`snapshot-latest\`](${{ github.server_url }}/${{ github.repository }}/releases/tag/snapshot-latest); portable Linux tarballs built fresh from this commit.
+          Existing platform tarballs promoted from [\`${{ needs.validate.outputs.snapshot_tag }}\`](${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.validate.outputs.snapshot_tag }}); portable Linux tarballs built fresh from this commit.
 
           **Existing platform tarballs** (RelWithDebInfo, distro-specific):
           - \`moxygen-<platform>.tar.gz\` — stripped release build

--- a/.github/workflows/omoq-version-release.yml
+++ b/.github/workflows/omoq-version-release.yml
@@ -81,13 +81,13 @@ jobs:
             runner: ubuntu-22.04
             cxx_flags: "-march=x86-64-v2 -fno-omit-frame-pointer -fasynchronous-unwind-tables"
             artifact: moxygen-linux-amd64.tar.gz
-            debug_artifact: moxygen-linux-amd64-symbols.tar.gz
+            debug_artifact: moxygen-linux-amd64-dbg.tar.gz
 
           - name: linux-arm64
             runner: ubuntu-22.04-arm
             cxx_flags: "-march=armv8-a -fno-omit-frame-pointer -fasynchronous-unwind-tables"
             artifact: moxygen-linux-arm64.tar.gz
-            debug_artifact: moxygen-linux-arm64-symbols.tar.gz
+            debug_artifact: moxygen-linux-arm64-dbg.tar.gz
 
     name: portable (${{ matrix.name }})
     runs-on: ${{ matrix.runner }}
@@ -246,9 +246,9 @@ jobs:
           **Portable Linux tarballs** (Release -O3, ISA-baselined, statically linked):
           - \`moxygen-linux-amd64.tar.gz\` — \`-march=x86-64-v2\` (≈ all cloud x86 since 2015)
           - \`moxygen-linux-arm64.tar.gz\` — \`-march=armv8-a\` (Graviton, Ampere, Apple M, RPi 3+, Rockchip)
-          - \`moxygen-linux-{amd64,arm64}-symbols.tar.gz\` — split debug symbols (.debug sidecar)
+          - \`moxygen-linux-{amd64,arm64}-dbg.tar.gz\` — split debug symbols (.debug sidecar)
 
-          Portable tarballs are compiled with frame pointers preserved (\`-fno-omit-frame-pointer -fasynchronous-unwind-tables\`) so signal-handler stack unwinding (folly::symbolizer) works against the .symbols sidecar even at \`-O3\`.
+          Portable tarballs are compiled with frame pointers preserved (\`-fno-omit-frame-pointer -fasynchronous-unwind-tables\`) so signal-handler stack unwinding (folly::symbolizer) works against the .dbg sidecar even at \`-O3\`.
           EOF
           )"
           echo "Released: $TAG"

--- a/.github/workflows/omoq-version-release.yml
+++ b/.github/workflows/omoq-version-release.yml
@@ -105,11 +105,18 @@ jobs:
     needs: [validate]
     runs-on: ubuntu-22.04
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OMOQ_APP_ID }}
+          private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
+
       - uses: actions/checkout@v4
 
-      - name: Create draft release
+      - name: Create release (no assets yet)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ needs.validate.outputs.version }}
           TAG: ${{ needs.validate.outputs.tag }}
           SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
@@ -118,7 +125,6 @@ jobs:
           gh release create "$TAG" \
             --target "$SNAPSHOT_SHA" \
             --title "moxygen $VERSION" \
-            --draft \
             --notes "$(cat <<EOF
           **Version:** \`${VERSION}\`
           **Commit:** \`${SNAPSHOT_SHA}\`
@@ -233,9 +239,16 @@ jobs:
             --debug-output "${{ matrix.debug_artifact }}"
           ls -lh "${{ matrix.artifact }}" "${{ matrix.debug_artifact }}"
 
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OMOQ_APP_ID }}
+          private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
+
       - name: Upload to release (binary + dbg in parallel)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
           # Upload binary and dbg sidecar in parallel from this runner.
@@ -254,9 +267,16 @@ jobs:
     needs: [validate, create-release]
     runs-on: ubuntu-22.04
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OMOQ_APP_ID }}
+          private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
+
       - name: Download snapshot tarballs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
         run: |
           mkdir -p snapshot-assets
@@ -270,7 +290,7 @@ jobs:
 
       - name: Upload to release (parallel)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
           # Fan out asset upload to N concurrent gh release upload calls.
@@ -288,10 +308,20 @@ jobs:
     needs: [validate, portable-build, promote-snapshot]
     runs-on: ubuntu-22.04
     steps:
-      - name: Publish release
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OMOQ_APP_ID }}
+          private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
+
+      - name: Mark release as latest
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
-          gh release edit "$TAG" --draft=false
+          # gh release create without --draft already creates a published
+          # release; this step is here so we can flip latest=true after
+          # all assets are up.
+          gh release edit "$TAG" --latest
           echo "Released: $TAG"

--- a/.github/workflows/omoq-version-release.yml
+++ b/.github/workflows/omoq-version-release.yml
@@ -35,6 +35,13 @@ on:
         required: true
         type: string
 
+# Serialize per-version dispatches: prevents two runs with the same
+# version from both passing validate's tag-doesn't-exist check and
+# then racing on create-release.
+concurrency:
+  group: version-release-${{ inputs.version }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -273,6 +280,23 @@ jobs:
         with:
           app-id: ${{ secrets.OMOQ_APP_ID }}
           private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
+
+      - name: Verify snapshot hasn't been replaced mid-flight
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
+          EXPECTED_SHA: ${{ needs.validate.outputs.snapshot_sha }}
+        run: |
+          CURRENT_SHA=$(gh api "repos/$REPO/releases" \
+            --jq ".[] | select(.tag_name == \"$SNAPSHOT_TAG\") | .target_commitish")
+          if [ "$CURRENT_SHA" != "$EXPECTED_SHA" ]; then
+            echo "Error: $SNAPSHOT_TAG was replaced mid-release." >&2
+            echo "  expected: $EXPECTED_SHA" >&2
+            echo "  current:  $CURRENT_SHA" >&2
+            echo "Retry the dispatch — ci-main published a new snapshot during this run." >&2
+            exit 1
+          fi
 
       - name: Download snapshot tarballs
         env:

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -27,6 +27,14 @@ option(BUNDLE_DEPS "Build all dep targets for artifact bundling" OFF)
 option(INSTALL_DEPS "Build and install all transitive dep targets" OFF)
 option(BUILD_PICOQUIC "Build with picoquic transport support" ON)
 
+# When ON, statically link glog/gflags/double-conversion into the bundled
+# artifact. OFF (default) preserves the legacy behavior where these libs
+# stay dynamic so consumers' find_package(Glog) etc. resolve to the same
+# system .so. ON is intended for portable production tarballs that need to
+# run across Ubuntu/Debian/RHEL releases without matching SONAMEs.
+option(BUNDLE_DEPS_STATIC_SYSLIBS
+    "Static-link glog/gflags/double-conversion in BUNDLE_DEPS artifact" OFF)
+
 # =============================================================================
 # Linking preferences
 # =============================================================================
@@ -93,17 +101,22 @@ list(APPEND CMAKE_MODULE_PATH
 )
 find_package(Threads REQUIRED)
 find_package(OpenSSL REQUIRED)
-# glog/gflags/double-conversion: find with .so preference so the tarball's
-# folly-targets.cmake hardcodes .so paths, not .a. Consumers that also
-# find_package(Glog) then get the same .so — no dual-linkage under ASAN.
-if(BUNDLE_DEPS AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+# Default (BUNDLE_DEPS_STATIC_SYSLIBS=OFF): prefer .so for these libs so
+# folly-targets.cmake hardcodes .so paths. Consumers' own find_package(Glog)
+# then resolve to the same .so — no dual-linkage under ASAN.
+# BUNDLE_DEPS_STATIC_SYSLIBS=ON: omit the override so the BUNDLE_DEPS
+# .a preference applies, statically linking glog/gflags/double-conversion
+# into the artifact for cross-distro portability.
+if(BUNDLE_DEPS AND CMAKE_SYSTEM_NAME STREQUAL "Linux"
+        AND NOT BUNDLE_DEPS_STATIC_SYSLIBS)
     set(_saved_suffixes "${CMAKE_FIND_LIBRARY_SUFFIXES}")
     set(CMAKE_FIND_LIBRARY_SUFFIXES ".so;.a")
 endif()
 find_package(gflags CONFIG REQUIRED)
 find_package(Glog REQUIRED)
 find_package(double-conversion CONFIG REQUIRED)
-if(BUNDLE_DEPS AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if(BUNDLE_DEPS AND CMAKE_SYSTEM_NAME STREQUAL "Linux"
+        AND NOT BUNDLE_DEPS_STATIC_SYSLIBS)
     set(CMAKE_FIND_LIBRARY_SUFFIXES "${_saved_suffixes}")
 endif()
 find_package(Boost 1.70 REQUIRED COMPONENTS


### PR DESCRIPTION
## Summary

Reshape \`omoq-version-release.yml\` to build the portable linux-amd64 / linux-arm64 production tarballs on demand as part of cutting a moxygen release, rather than on every push to main.

This is the principled re-land of the work reverted in #189 (which itself reverted #184). The previous approach put portable builds on the rolling \`snapshot-latest\` path, which was too expensive and caused the \`BUILD_TESTS=OFF\` entanglement that broke moqx \`find_package(GTest)\`. By isolating portable builds to the \`workflow_dispatch\` release path, we keep the rolling snapshot fast and untouched, and only pay the portable build cost when explicitly cutting a release.

## What's in the release tarball set

Three jobs in the new flow:

- **\`validate\`** — semver gate + tag-doesn't-exist precheck
- **\`portable-build\`** — matrix \`linux-amd64\` / \`linux-arm64\`. \`-O3\`, \`-march=<x86-64-v2|armv8-a>\`, \`-fno-omit-frame-pointer -fasynchronous-unwind-tables\`, \`BUNDLE_DEPS_STATIC_SYSLIBS=ON\`, \`-fno-lto\`, PIE. Produces \`moxygen-linux-<arch>.tar.gz\` + \`-symbols.tar.gz\` debug sidecar.
- **\`release\`** — promotes bookworm/ubuntu/macos tarballs from \`snapshot-latest\`, combines with fresh portables, calls \`gh release create v<version>\`.

\`BUILD_TESTS=ON\` is retained in portable-build so \`lib/cmake/GTest/GTestConfig.cmake\` lands in the tarball (moqx consumers need it). \`BUILD_TESTING=OFF\` still suppresses actual test execution. This is the sweet spot the \`-DBUILD_TESTS=OFF\` regression in #184 missed.

## Frame pointers + -O3

Per requirement: production-optimized portable builds must remain debuggable. Frame pointers preserved at \`-O3\` enables signal-handler stack unwinding (\`folly::symbolizer\`) and post-mortem analysis via the \`.symbols\` sidecar even at the highest optimization level. Small (~1-2%) perf cost in exchange for actionable crash reports from users running production binaries.

## Standalone cmake

Re-adds \`BUNDLE_DEPS_STATIC_SYSLIBS\` option to \`standalone/CMakeLists.txt\` that #189 removed alongside the rest of #184. Needed only by the portable matrix; default OFF preserves snapshot-latest behavior.

## Test plan

- [x] Manual \`workflow_dispatch\` of \`version release\` with a temporary version (e.g., \`0.0.1-rc1\`); verify \`portable-build\` matrix succeeds on both linux-amd64 / linux-arm64.
- [x] Verify the resulting \`v0.0.1-rc1\` release contains: \`moxygen-bookworm-{amd64,arm64}.tar.gz\`, \`moxygen-ubuntu-22.04-amd64.tar.gz\`, \`moxygen-macos-15-arm64.tar.gz\` (promoted from snapshot-latest), plus \`moxygen-linux-{amd64,arm64}.tar.gz\` and \`moxygen-linux-{amd64,arm64}-symbols.tar.gz\` (built fresh).
- [x] Verify each portable tarball contains \`lib/cmake/GTest/GTestConfig.cmake\` (so moqx \`find_package(GTest)\` resolves against it).
- [x] Verify \`.symbols.tar.gz\` sidecars carry .debug files corresponding to the bin/ executables.
- [ ] Verify portable binary runs on a non-jammy distro (RHEL 9 or noble) — no SONAME complaints from glog/gflags/double-conversion.
- [ ] Delete the test release/tag after validation.

## Follow-on (separate PR)

moqx \`release/test-portable-tarballs\` branch will gain:
- gating publish-portable in \`ci-main.yml\` to \`startsWith(github.ref, 'refs/heads/release/')\` so main pushes don't build it
- a new \`version-release.yml\` workflow that takes \`version\` + \`moxygen_release\` inputs, cuts \`release/v<version>\` from main, writes \`.moxygen-release\` = \`<moxygen_release>\`, and lets ci-main build the moqx portable tarballs against the pinned moxygen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/194)
<!-- Reviewable:end -->
