### PR TITLE
docs: replace top-level CONTRIBUTING.md with openmoq fork stub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,34 +1,6 @@
-# Contributing to Meta Open Source Projects
+# Contributing
 
-We want to make contributing to this project as easy and transparent as
-possible.
+This is **openmoq/moxygen**, a community-maintained fork of [facebookexperimental/moxygen](https://github.com/facebookexperimental/moxygen).
 
-## Pull Requests
-We actively welcome your pull requests.
-
-Note: pull requests are not imported into the GitHub directory in the usual way. There is an internal Meta repository that is the "source of truth" for the project. The GitHub repository is generated *from* the internal Meta repository. So we don't merge GitHub PRs directly to the GitHub repository -- they must first be imported into internal Meta repository. When Meta employees look at the GitHub PR, there is a special button visible only to them that executes that import. The changes are then automatically reflected from the internal Meta repository back to GitHub. This is why you won't see your PR having being directly merged, but you still see your changes in the repository once it reflects the imported changes.
-
-1. Fork the repo and create your branch from `main`.
-2. If you've added code that should be tested, add tests.
-3. If you've changed APIs, update the documentation.
-4. Ensure the test suite passes.
-5. Make sure your code lints.
-6. If you haven't already, complete the Contributor License Agreement ("CLA").
-
-## Contributor License Agreement ("CLA")
-In order to accept your pull request, we need you to submit a CLA. You only need
-to do this once to work on any of Meta's open source projects.
-
-Complete your CLA here: <https://code.facebook.com/cla>
-
-## Issues
-We use GitHub issues to track public bugs. Please ensure your description is
-clear and has sufficient instructions to be able to reproduce the issue.
-
-Meta has a [bounty program](https://www.facebook.com/whitehat/) for the safe
-disclosure of security bugs. In those cases, please go through the process
-outlined on that page and do not file a public issue.
-
-## License
-By contributing to this project, you agree that your contributions will be licensed
-under the LICENSE file in the root directory of this source tree.
+- **Contributing to this fork:** see [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md).
+- **Contributing upstream:** see the [upstream CONTRIBUTING.md](https://github.com/facebookexperimental/moxygen/blob/main/CONTRIBUTING.md) for the Meta repo's process (CLA, internal repo workflow, etc.).


### PR DESCRIPTION
Fixes #167.

## Summary

Replace upstream Meta's CONTRIBUTING.md at top-level with a brief stub that identifies this as a fork and points contributors to the right place. Closes the "developers see Meta CLA process and think it applies here" confusion that #167 raised.

## Diff

- Top-level `CONTRIBUTING.md`: Meta's 35-line upstream doc → 6-line openmoq fork stub.
- `.github/CONTRIBUTING.md`: untouched (canonical fork doc lives here, GitHub UI prefers it).

## Why a stub instead of full overwrite

- **No duplicate content** between top-level and `.github/`. Single source of truth in `.github/`.
- **URL link to upstream stays current automatically.** The stub references upstream's CONTRIBUTING.md by URL, not by copied content, so Meta can rewrite their doc anytime and our link still resolves to the latest.
- **Disambiguates for terminal-cat readers.** A developer running `cat CONTRIBUTING.md` from a clone now sees "this is openmoq's fork — see .github/CONTRIBUTING.md or upstream's" instead of Meta's CLA process. GitHub PR-flow contributors were already seeing `.github/CONTRIBUTING.md` because GH UI prefers it; this just closes the terminal-cat hole.
- **Lower maintenance.** ~140 lines fewer to keep in sync than a full carry-patch overwrite.

## Carry-patch survival

The stub diverges completely from upstream's CONTRIBUTING.md, so any future upstream change creates a hunk conflict and `omoq-upstream-sync.yml`'s `git merge -X ours` resolution keeps our stub. Upstream changes are silently swallowed at the merge level — but that's fine for this carry-patch because the stub doesn't copy content, only links to upstream by URL. The link remains correct as upstream evolves.

## Test plan

- [x] Verify `.github/CONTRIBUTING.md` renders correctly in GitHub's "Contributing guidelines" UI link (community profile / PR template) — should still surface openmoq's full doc as before.
- [x] Verify top-level `CONTRIBUTING.md` renders cleanly in repo root view.
- [ ] Verify both relative links in the stub resolve: `[.github/CONTRIBUTING.md](.github/CONTRIBUTING.md)` and the absolute upstream URL.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/197)
<!-- Reviewable:end -->
