### PR TITLE
hotfix: cron cascade shift + version-release prerelease + auto-latest

### DIFF
--- a/.github/workflows/omoq-picoquic-sync.yml
+++ b/.github/workflows/omoq-picoquic-sync.yml
@@ -11,11 +11,11 @@ name: picoquic sync
 on:
   schedule:
     # Third stage of the openmoq sync cron cascade (UTC; ET shifts under DST):
-    #   04:35  picoquic upstream-sync     (private-octopus → openmoq/picoquic)
-    #   05:35  moxygen  upstream-sync     (facebookexperimental → openmoq/moxygen)
-    #   05:45  moxygen  picoquic-pin sync (this workflow — openmoq/picoquic → moxygen picoquic-rev.txt)
-    #   09:05  moqx     moxygen-submodule sync (openmoq/moxygen → moqx deps/moxygen)
-    - cron: '45 5 * * *'
+    #   03:23  picoquic upstream-sync     (private-octopus → openmoq/picoquic)
+    #   04:23  moxygen  upstream-sync     (facebookexperimental → openmoq/moxygen)
+    #   04:37  moxygen  picoquic-pin sync (this workflow — openmoq/picoquic → moxygen picoquic-rev.txt)
+    #   08:23  moqx     moxygen-submodule sync (openmoq/moxygen → moqx deps/moxygen)
+    - cron: '37 4 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/omoq-upstream-sync.yml
+++ b/.github/workflows/omoq-upstream-sync.yml
@@ -14,11 +14,11 @@ name: upstream sync
 on:
   schedule:
     # Second stage of the openmoq sync cron cascade (UTC; ET shifts under DST):
-    #   04:35  picoquic upstream-sync     (private-octopus → openmoq/picoquic)
-    #   05:35  moxygen  upstream-sync     (this workflow — facebookexperimental → openmoq/moxygen)
-    #   05:45  moxygen  picoquic-pin sync (openmoq/picoquic → moxygen picoquic-rev.txt)
-    #   09:05  moqx     moxygen-submodule sync (openmoq/moxygen → moqx deps/moxygen)
-    - cron: '35 5 * * *'
+    #   03:23  picoquic upstream-sync     (private-octopus → openmoq/picoquic)
+    #   04:23  moxygen  upstream-sync     (this workflow — facebookexperimental → openmoq/moxygen)
+    #   04:37  moxygen  picoquic-pin sync (openmoq/picoquic → moxygen picoquic-rev.txt)
+    #   08:23  moqx     moxygen-submodule sync (openmoq/moxygen → moqx deps/moxygen)
+    - cron: '23 4 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/omoq-version-release.yml
+++ b/.github/workflows/omoq-version-release.yml
@@ -129,9 +129,16 @@ jobs:
           SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
           SNAPSHOT_SHA: ${{ needs.validate.outputs.snapshot_sha }}
         run: |
+          # Mark prereleases (1.2.3-rc1) as such so GitHub's "latest"
+          # algorithm correctly excludes them.
+          PRERELEASE_FLAG=()
+          if [[ "$VERSION" == *-* ]]; then
+            PRERELEASE_FLAG=(--prerelease)
+          fi
           gh release create "$TAG" \
             --target "$SNAPSHOT_SHA" \
             --title "moxygen $VERSION" \
+            "${PRERELEASE_FLAG[@]}" \
             --notes "$(cat <<EOF
           **Version:** \`${VERSION}\`
           **Commit:** \`${SNAPSHOT_SHA}\`
@@ -341,14 +348,15 @@ jobs:
           app-id: ${{ secrets.OMOQ_APP_ID }}
           private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
 
-      - name: Mark release as latest
+      - name: Confirm release published
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
-          # gh release create without --draft already creates a published
-          # release; this step is here so we can flip latest=true after
-          # all assets are up.
-          gh release edit "$TAG" --repo "$REPO" --latest
+          # No --latest flag here. Let GitHub's auto-latest algorithm
+          # pick the highest non-prerelease semver tag. Forcing --latest
+          # would mark a hotfix patch from a release/vM.m branch as
+          # latest even when a newer vM.(m+1) line exists.
           echo "Released: $TAG"
+          gh release view "$TAG" --repo "$REPO" --json isLatest,isPrerelease,name --jq '"isLatest=\(.isLatest) isPrerelease=\(.isPrerelease) name=\(.name)"'


### PR DESCRIPTION
## Summary

Three small, related fixes to the release/sync infrastructure.

### 1. Cron cascade shift (1h earlier, on :23 / :37)

GitHub Actions schedule triggers were firing ~2-3h late under load. Shifting off the top-of-hour and 1 hour earlier should improve reliability:

| Stage | Was | Now |
|---|---|---|
| picoquic upstream-sync | 04:35 | 03:23 |
| moxygen upstream-sync (this repo) | 05:35 | **04:23** |
| moxygen picoquic-pin sync (this repo) | 05:45 | **04:37** |
| moqx moxygen-submodule sync | 09:05 | 08:23 |

Inter-stage spacing preserved so the cascade still chains correctly even if individual stages drift.

### 2. version-release prerelease detection

Detect semver prerelease identifier (e.g., `1.2.3-rc1`, `1.2.3-rc-1`) in the `version` input and pass `--prerelease` to `gh release create`. Without this, prereleases land as non-prereleases and contaminate GitHub's "latest" algorithm.

### 3. Drop forced --latest from finalize

The explicit `gh release edit --latest` would incorrectly mark a hotfix patch from a `release/vM.m` branch as Latest even when a newer `vM.(m+1)` line exists. Let GitHub's auto-latest pick the highest non-prerelease semver tag.

## Companion PRs

Sibling repos:
- openmoq/picoquic — cron 04:35 → 03:23
- openmoq/moqx — cron 09:05 → 08:23 + version-release input normalization + branch-aware default

## Test plan

- [ ] Cron next-firing time on each shifted workflow is correct (visible in Actions tab "Run workflow" page or `gh api repos/X/actions/workflows/Y` with `state=active`).
- [ ] Manual `workflow_dispatch` of `version release` with `version=0.0.1-rc1` produces a release marked `isPrerelease=true` and not picked as latest.
- [ ] `version release` with `version=0.2.0` from main produces a release with `isLatest=true` (auto-determined by GitHub).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/198)
<!-- Reviewable:end -->
