### PR TITLE
feat (pico): expose RTT, receive rate, and bytes-in-transit in PathQualityDelta

### DIFF
--- a/moxygen/openmoq/transport/pico/MoQPicoServerBase.cpp
+++ b/moxygen/openmoq/transport/pico/MoQPicoServerBase.cpp
@@ -236,6 +236,9 @@ static int picoCallback(
       d.timerLosses = cur.timer_losses - prev.timer_losses;
       d.spuriousLosses = cur.spurious_losses - prev.spurious_losses;
       d.cwndBlocked = (cur.cwin > 0 && cur.bytes_in_transit >= cur.cwin);
+      d.smoothedRttUs = cur.rtt;
+      d.receiveBytesPerSec = cur.receive_rate_estimate;
+      d.bytesInTransit = cur.bytes_in_transit;
       ctx->statsCallback->onPathQualityDelta(d);
       ctx->prevPathQuality = cur;
     }
@@ -408,6 +411,11 @@ bool MoQPicoServerBase::createQuicContext() {
   picoquic_set_default_priority(quic_, transportConfig_.defaultStreamPriority);
   picoquic_set_default_datagram_priority(
       quic_, transportConfig_.defaultDatagramPriority);
+
+  // Enable path quality change callbacks for all connections.
+  // Fires picoquic_callback_path_quality_changed when pacing rate changes by
+  // >100 KB/s or RTT changes by >1 ms.
+  picoquic_default_quality_update(quic_, 100000, 1000);
 
   // Initialize h3zero for WebTransport if enabled
   if (wtConfig_.enableWebTransport) {

--- a/moxygen/openmoq/transport/pico/PicoQuicStatsCallback.h
+++ b/moxygen/openmoq/transport/pico/PicoQuicStatsCallback.h
@@ -59,9 +59,13 @@ class PicoQuicStatsCallback {
     uint64_t packetsLost{0};
     uint64_t bytesSent{0};
     uint64_t bytesReceived{0};
-    uint64_t timerLosses{0};    // losses detected by RTO timer
-    uint64_t spuriousLosses{0}; // packets later acknowledged (false losses)
+    uint64_t timerLosses{0};    // losses detected by RTO timer (triggers retransmit)
+    uint64_t spuriousLosses{0}; // packets later acknowledged (false losses, no retransmit)
     bool cwndBlocked{false};    // bytes_in_transit >= cwin at this sample point
+    // Point-in-time samples (current values, not deltas)
+    uint64_t smoothedRttUs{0};      // smoothed RTT in microseconds
+    uint64_t receiveBytesPerSec{0}; // receive rate estimate in bytes/second
+    uint64_t bytesInTransit{0};     // bytes currently in flight
   };
   virtual void onPathQualityDelta(const PathQualityDelta& delta) = 0;
 };


### PR DESCRIPTION
Adds point-in-time samples (smoothedRttUs, receiveBytesPerSec, bytesInTransit) to PathQualityDelta and enables path quality change callbacks via picoquic_default_quality_update so callers receive the event when pacing rate or RTT shifts meaningfully.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/199)
<!-- Reviewable:end -->
