### PR TITLE
fix: remove picoquic_create 100-connection cap

### DIFF
--- a/moxygen/openmoq/transport/pico/MoQPicoServerBase.cpp
+++ b/moxygen/openmoq/transport/pico/MoQPicoServerBase.cpp
@@ -319,7 +319,7 @@ bool MoQPicoServerBase::createQuicContext() {
 
   uint64_t current_time = picoquic_current_time();
   quic_ = picoquic_create(
-      100,
+      1000000,
       cert_.c_str(),
       key_.c_str(),
       nullptr, // cert_store_filename


### PR DESCRIPTION
The hardcoded limit of 100 simultaneous QUIC connections was a leftover default that blocks production deployments with more concurrent clients.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/200)
<!-- Reviewable:end -->
