### PR TITLE
ci: auto-delete sync-* branches when PRs closed without merge

### DIFF
--- a/.github/workflows/sync-branch-cleanup-on-close.yml
+++ b/.github/workflows/sync-branch-cleanup-on-close.yml
@@ -1,0 +1,48 @@
+name: sync branch cleanup on close
+
+# Auto-deletes the head branch when a sync PR is closed without merging.
+# Scoped to branches whose names start with `sync/` or `sync-` so we only
+# touch automation-managed branches — feature/fix/devops branches are not
+# affected by this workflow.
+#
+# Why this exists: the repo setting "Automatically delete head branches"
+# only applies to MERGED PRs. Sync PRs that fail (e.g., CI red, approve
+# step blocked, manual close to retry) leave their branch on remote.
+# When the next sync run targets the same upstream SHA, the branch name
+# collides and `git push` fails with non-fast-forward. This cleans up
+# preemptively so close-and-rerun is reliable even when the SHA hasn't
+# advanced.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    if: |
+      github.event.pull_request.merged == false
+      && (startsWith(github.event.pull_request.head.ref, 'sync/')
+          || startsWith(github.event.pull_request.head.ref, 'sync-'))
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Delete head branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          # Defense: head branch must live in this repo (not a fork).
+          # We don't have permission to delete branches in someone else's fork.
+          if [ "$HEAD_REPO" != "$REPO" ]; then
+            echo "PR head is in fork ${HEAD_REPO} — skipping (cannot delete branches in forks)"
+            exit 0
+          fi
+
+          echo "Deleting ${REPO}/${BRANCH} (sync PR closed without merge)"
+          gh api -X DELETE "repos/${REPO}/git/refs/heads/${BRANCH}" \
+            && echo "Deleted ${BRANCH}" \
+            || echo "Branch already gone or never existed — no-op"


### PR DESCRIPTION
## Summary

Add a small workflow that auto-deletes the head branch when any PR with a `sync/*` or `sync-*` head ref is **closed without merging**. Fills the gap left by the repo-level "Automatically delete head branches" setting, which only fires on merge.

## Why

When a sync PR fails or is closed for retry, the branch lingers on remote. If the next sync run targets the **same upstream SHA** — rare but it happens when upstream hasn't advanced between attempts — the branch name collides and `git push` fails with non-fast-forward, blocking the cron cascade until the orphan is manually deleted.

Hit this exact failure mode today:
- picoquic: `sync/f54239a39145` collision after manual squash-merge of PR #7 left the branch on remote (`delete_branch_on_merge` fires only after `--merge`, not in all manual flows).
- moxygen: `sync-picoquic/0c516acd3b57` collision after manual close of PR #203 (no `--delete-branch`).

This workflow makes close-and-rerun reliable in all cases.

## Scope

- Triggers on `pull_request: closed`.
- Gated on `merged == false` (so it only runs for non-merge closes — `delete_branch_on_merge` already handles merges).
- Gated on head-ref prefix `sync/` or `sync-` — only automation-managed branches. Feature/fix/devops branches are unaffected.
- Skips fork PRs (we can't delete branches in someone else's fork).
- Uses default `GITHUB_TOKEN` with `contents: write` — no app token needed for a same-repo branch delete.

## Test plan

- [ ] After merge, manually close a sync-prefixed PR (existing or new) without merging — verify the branch disappears on remote.
- [ ] Manually close a non-sync PR (e.g., a feature/fix branch) — verify the branch is NOT deleted (workflow's `if:` guard rejects).
- [ ] Verify the workflow doesn't fire on PR `opened`, `synchronize`, or `merged` events (only `closed`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/205)
<!-- Reviewable:end -->
