### PR TITLE
ci: reclaim orphan sync branches inline in sync workflows

### DIFF
--- a/.github/workflows/omoq-picoquic-sync.yml
+++ b/.github/workflows/omoq-picoquic-sync.yml
@@ -92,6 +92,22 @@ jobs:
           SHORT_SHA="${{ steps.compare.outputs.short_sha }}"
           CURRENT_SHORT="${CURRENT_SHA:0:12}"
           BRANCH="sync-picoquic/$SHORT_SHA"
+          REPO="${{ github.repository }}"
+
+          # Reclaim orphan branch if it exists with no open PR. PHASE A's
+          # blocking check rejects when an open sync-picoquic/* PR is pending,
+          # so by this point any pre-existing branch with no open PR is from a
+          # prior closed-without-merge sync attempt — safe to delete.
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            EXISTING_PR=$(gh pr list --repo "$REPO" --state open --head "$BRANCH" \
+              --json number --jq '.[0].number // empty' 2>/dev/null || true)
+            if [ -n "$EXISTING_PR" ]; then
+              echo "::error::Branch $BRANCH already used by open PR #$EXISTING_PR — aborting"
+              exit 1
+            fi
+            echo "::warning::Deleting orphan $BRANCH (closed PR or stale push, no open PR)"
+            gh api -X DELETE "repos/$REPO/git/refs/heads/$BRANCH"
+          fi
 
           git config user.email "omoq-sync-bot[bot]@users.noreply.github.com"
           git config user.name "omoq-sync-bot[bot]"

--- a/.github/workflows/omoq-upstream-sync.yml
+++ b/.github/workflows/omoq-upstream-sync.yml
@@ -229,6 +229,22 @@ jobs:
           FULL_SHA="${{ steps.upstream.outputs.upstream_sha }}"
           SYNC_SHA="${{ steps.upstream.outputs.short_sha }}"
           BRANCH="sync/$SYNC_SHA"
+          REPO="${{ github.repository }}"
+
+          # Reclaim orphan branch if it exists with no open PR. PHASE A's
+          # blocking check rejects when an open sync/* PR is pending, so by
+          # this point any pre-existing branch with no open PR is from a
+          # prior closed-without-merge sync attempt — safe to delete.
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            EXISTING_PR=$(gh pr list --repo "$REPO" --state open --head "$BRANCH" \
+              --json number --jq '.[0].number // empty' 2>/dev/null || true)
+            if [ -n "$EXISTING_PR" ]; then
+              echo "::error::Branch $BRANCH already used by open PR #$EXISTING_PR — aborting"
+              exit 1
+            fi
+            echo "::warning::Deleting orphan $BRANCH (closed PR or stale push, no open PR)"
+            gh api -X DELETE "repos/$REPO/git/refs/heads/$BRANCH"
+          fi
 
           # Create sync branch directly from the chosen upstream SHA
           git push origin "$FULL_SHA:refs/heads/$BRANCH"


### PR DESCRIPTION
## Summary

Add a defensive **orphan-reclaim** block to each sync workflow's create-branch step. When a sync PR is closed without merging, its head branch lingers on remote — the repo "Automatically delete head branches" setting only fires on merge, not close. If the next sync workflow run targets the same upstream SHA (rare but possible when upstream hasn't advanced between attempts), the branch name collides and `git push` fails with non-fast-forward, blocking the cron cascade.

## Behavior

Before each sync workflow's `git push`:

1. Check if the target branch exists on remote.
2. If yes, check whether any open PR uses it as head.
   - **Open PR exists** → abort with explicit error (defensive — PHASE A's blocking check should already have caught this).
   - **No open PR** → it's an orphan from a closed-without-merge attempt. Delete it.
3. Proceed with push as normal.

Net effect: closing a sync PR + re-running the workflow now works unconditionally, even when the upstream SHA hasn't changed between attempts. No manual branch cleanup, no separate cleanup workflow with skipped run noise.

## Why inline instead of a separate cleanup workflow

Earlier today we tried a `pull_request: closed` workflow (since-closed PR #10 in picoquic, closed PRs #205 in moxygen / #289 in moqx). It worked but produced "skipped" run records on every PR close in the repo (GitHub doesn't support head-branch filtering on `pull_request` triggers). Visual noise on the Actions UI made non-green entries unreliable as a problem signal.

Weaving the cleanup into the sync workflow itself fixes the same problem with no Actions UI noise — the cleanup only happens when actually needed, as part of the normal sync run.

## Test plan

- [ ] Manually close a sync PR without merging — confirm the orphan branch lingers (existing behavior).
- [ ] Re-run the sync workflow (`gh workflow run`) — confirm the orphan-reclaim warning fires and the new sync PR opens cleanly.
- [ ] Verify the abort path: if you somehow get into a state with an open PR for the target branch, the workflow should error explicitly rather than silently force-pushing.

## Related

- This PR removes `.github/workflows/sync-branch-cleanup-on-close.yml` — the close-trigger workflow merged via PR #10. Picoquic-only; the same change in moxygen / moqx never merged. (Picoquic PR only.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/206)
<!-- Reviewable:end -->
