### PR TITLE
pico: add onPacketsSent/onPacketsReceived to PicoQuicStatsCallback

### DIFF
--- a/moxygen/openmoq/transport/pico/MoQPicoQuicEventBaseServer.cpp
+++ b/moxygen/openmoq/transport/pico/MoQPicoQuicEventBaseServer.cpp
@@ -57,6 +57,9 @@ void MoQPicoQuicEventBaseServer::start(const folly::SocketAddress& addr) {
   XLOG(INFO) << "Starting MoQPicoQuicEventBaseServer on " << addr.describe();
 
   impl_->handler = std::make_unique<PicoQuicSocketHandler>(evb_.get(), quic_);
+  if (auto* cb = statsCallbackRaw()) {
+    impl_->handler->setStatsCallback(cb);
+  }
   impl_->handler->start(addr);
 }
 

--- a/moxygen/openmoq/transport/pico/MoQPicoServerBase.h
+++ b/moxygen/openmoq/transport/pico/MoQPicoServerBase.h
@@ -68,6 +68,14 @@ class MoQPicoServerBase : public MoQServerBase {
 
  protected:
   /**
+   * Returns the raw stats callback pointer for subclasses that need to wire
+   * it into lower-level I/O handlers (e.g. PicoQuicSocketHandler).
+   */
+  PicoQuicStatsCallback* statsCallbackRaw() const {
+    return statsCallback_.get();
+  }
+
+  /**
    * Creates and configures the picoquic_quic_t context:
    *   picoquic_create + ALPN selection callback + cookie mode + BBR.
    * Sets quic_. executor_ must already be set.

--- a/moxygen/openmoq/transport/pico/PicoQuicSocketHandler.cpp
+++ b/moxygen/openmoq/transport/pico/PicoQuicSocketHandler.cpp
@@ -207,6 +207,9 @@ void PicoQuicSocketHandler::onNotifyDataAvailable(
   if (anyReceived) {
     XLOG(DBG5) << "onNotifyDataAvailable: received " << totalReceived
                << " packets, draining";
+    if (statsCallback_) {
+      statsCallback_->onPacketsReceived(static_cast<uint64_t>(totalReceived));
+    }
     drainOutgoing();
     if (pendingClose_) {
       stop();
@@ -390,6 +393,10 @@ void PicoQuicSocketHandler::drainOutgoing() {
     ++packetsSent;
 
     sendPacket(sendBuf, sendLength, addrTo, addrFrom, ifIndex, sendMsgSize);
+  }
+
+  if (statsCallback_ && packetsSent > 0) {
+    statsCallback_->onPacketsSent(static_cast<uint64_t>(packetsSent));
   }
 }
 

--- a/moxygen/openmoq/transport/pico/PicoQuicSocketHandler.h
+++ b/moxygen/openmoq/transport/pico/PicoQuicSocketHandler.h
@@ -8,6 +8,7 @@
 
 #include <folly/io/async/AsyncTimeout.h>
 #include <folly/io/async/AsyncUDPSocket.h>
+#include <moxygen/openmoq/transport/pico/PicoQuicStatsCallback.h>
 
 // Forward declaration — avoids picoquic.h in this header
 typedef struct st_picoquic_quic_t picoquic_quic_t;
@@ -73,6 +74,13 @@ class PicoQuicSocketHandler
     return socket_.address();
   }
 
+  /**
+   * Attach a stats callback. Must be called before start(). Non-owning.
+   */
+  void setStatsCallback(PicoQuicStatsCallback* cb) {
+    statsCallback_ = cb;
+  }
+
  private:
   void pauseRead();
 
@@ -114,6 +122,7 @@ class PicoQuicSocketHandler
   folly::AsyncUDPSocket socket_;
   picoquic_quic_t* quic_; // non-owning
   folly::EventBase* evb_; // non-owning
+  PicoQuicStatsCallback* statsCallback_{nullptr}; // non-owning, optional
   int fd_{-1};
   int socketFamily_{AF_UNSPEC}; // AF_INET or AF_INET6, set in start()
   bool gsoSupported_{false};

--- a/moxygen/openmoq/transport/pico/PicoQuicStatsCallback.h
+++ b/moxygen/openmoq/transport/pico/PicoQuicStatsCallback.h
@@ -68,6 +68,18 @@ class PicoQuicStatsCallback {
     uint64_t bytesInTransit{0};     // bytes currently in flight
   };
   virtual void onPathQualityDelta(const PathQualityDelta& delta) = 0;
+
+  /**
+   * Called from PicoQuicSocketHandler::drainOutgoing after each drain pass
+   * with the number of UDP datagrams actually sent in that pass.
+   */
+  virtual void onPacketsSent(uint64_t /*n*/) {}
+
+  /**
+   * Called from PicoQuicSocketHandler::onNotifyDataAvailable after each
+   * recvmmsg drain loop with the total datagrams received.
+   */
+  virtual void onPacketsReceived(uint64_t /*n*/) {}
 };
 
 } // namespace moxygen


### PR DESCRIPTION
Add onPacketsSent(n) and onPacketsReceived(n) to PicoQuicStatsCallback with default no-op implementations. Bump them from PicoQuicSocketHandler:
- drainOutgoing() calls onPacketsSent with total packets sent per drain pass
- onNotifyDataAvailable() calls onPacketsReceived with recvmmsg batch total

Wire the callback into PicoQuicSocketHandler via setStatsCallback(), called from MoQPicoQuicEventBaseServer::start() using a new protected statsCallbackRaw() accessor on MoQPicoServerBase.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/208)
<!-- Reviewable:end -->
