### PR TITLE
relay: channel subscriber support + const void* map key in MoQForwarder

### DIFF
--- a/moxygen/relay/MoQForwarder.cpp
+++ b/moxygen/relay/MoQForwarder.cpp
@@ -183,7 +183,7 @@ std::shared_ptr<MoQForwarder::Subscriber> MoQForwarder::addSubscriber(
     XLOG(ERR) << "addSubscriber called on draining track";
     return nullptr;
   }
-  auto sessionPtr = session.get();
+  const void* key = static_cast<const void*>(session.get());
   auto trackAlias = trackAlias_.value_or(subReq.requestID.value);
   XCHECK(consumer);
   consumer->setTrackAlias(trackAlias);
@@ -201,11 +201,12 @@ std::shared_ptr<MoQForwarder::Subscriber> MoQForwarder::addSubscriber(
       toSubscribeRange(subReq, largest_),
       std::move(consumer),
       subReq.forward);
+  subscriber->mapKey = key;
   // If the session already has a subscriber (e.g. from a prior
   // addSubscriber(session, forward) call), emplace is a no-op. Return the
   // existing in-map entry and only increment the forwarding count when a new
   // entry was actually inserted.
-  auto [it, inserted] = subscribers_.emplace(sessionPtr, subscriber);
+  auto [it, inserted] = subscribers_.emplace(key, subscriber);
   if (inserted && subReq.forward) {
     addForwardingSubscriber();
   }
@@ -219,7 +220,7 @@ std::shared_ptr<MoQForwarder::Subscriber> MoQForwarder::addSubscriber(
     XLOG(ERR) << "addSubscriber called on draining track";
     return nullptr;
   }
-  auto sessionPtr = session.get();
+  const void* key = static_cast<const void*>(session.get());
   auto subscriber = std::make_shared<MoQForwarder::Subscriber>(
       *this,
       SubscribeOk{
@@ -234,7 +235,8 @@ std::shared_ptr<MoQForwarder::Subscriber> MoQForwarder::addSubscriber(
       SubscribeRange{{0, 0}, kLocationMax},
       nullptr,
       forward);
-  auto [it, inserted] = subscribers_.emplace(sessionPtr, subscriber);
+  subscriber->mapKey = key;
+  auto [it, inserted] = subscribers_.emplace(key, subscriber);
   if (inserted && forward) {
     addForwardingSubscriber();
   }
@@ -250,7 +252,7 @@ std::shared_ptr<MoQForwarder::Subscriber> MoQForwarder::addSubscriber(
     XLOG(ERR) << "addSubscriber called on draining track";
     return nullptr;
   }
-  auto sessionPtr = session.get();
+  const void* key = static_cast<const void*>(session.get());
   if (consumer && trackAlias_) {
     consumer->setTrackAlias(*trackAlias_);
   }
@@ -269,7 +271,8 @@ std::shared_ptr<MoQForwarder::Subscriber> MoQForwarder::addSubscriber(
       std::move(consumer),
       forward);
   subscriber->passive = passive;
-  auto [it, inserted] = subscribers_.emplace(sessionPtr, subscriber);
+  subscriber->mapKey = key;
+  auto [it, inserted] = subscribers_.emplace(key, subscriber);
   if (inserted) {
     if (passive) {
       passiveCount_++;
@@ -280,10 +283,89 @@ std::shared_ptr<MoQForwarder::Subscriber> MoQForwarder::addSubscriber(
   return it->second;
 }
 
+std::shared_ptr<MoQForwarder::Subscriber> MoQForwarder::addChannelSubscriber(
+    folly::Executor* exec,
+    bool forward,
+    std::shared_ptr<TrackConsumer> consumer) {
+  if (draining_) {
+    XLOG(ERR) << "addChannelSubscriber called on draining track";
+    return nullptr;
+  }
+  const void* key = static_cast<const void*>(exec);
+  if (consumer && trackAlias_) {
+    consumer->setTrackAlias(*trackAlias_);
+  }
+  auto subscriber = std::make_shared<MoQForwarder::Subscriber>(
+      *this,
+      SubscribeOk{
+          RequestID(0),
+          trackAlias_.value_or(TrackAlias(0)),
+          std::chrono::milliseconds(0),
+          groupOrder_,
+          largest_,
+          extensions_},
+      nullptr, // no session
+      RequestID(0),
+      SubscribeRange{{0, 0}, kLocationMax},
+      std::move(consumer),
+      forward);
+  subscriber->mapKey = key;
+  auto [it, inserted] = subscribers_.emplace(key, subscriber);
+  if (inserted && forward) {
+    addForwardingSubscriber();
+  }
+  return it->second;
+}
+
+void MoQForwarder::drainSubscriberByKey(
+    const void* mapKey,
+    PublishDone pubDone,
+    const std::string& callsite) {
+  auto subIt = subscribers_.find(mapKey);
+  if (subIt == subscribers_.end()) {
+    XLOG(DBG1) << "Key not found in drainSubscriberByKey from " << callsite;
+    return;
+  }
+  auto sub = subIt->second; // own a ref so the object stays alive through removeSubscriberIt
+  pubDone.requestID = sub->requestID;
+  if (sub->trackConsumer) {
+    sub->trackConsumer->publishDone(std::move(pubDone));
+  }
+  if (sub->subgroups.empty()) {
+    removeSubscriberIt(subIt, std::nullopt, callsite);
+  } else {
+    sub->receivedPublishDone_ = true;
+  }
+}
+
+void MoQForwarder::removeChannelSubscriber(
+    const std::shared_ptr<MoQForwarder::Subscriber>& handle,
+    std::optional<PublishDone> pubDone) {
+  if (!handle) {
+    return;
+  }
+  auto subIt = subscribers_.find(handle->mapKey);
+  if (subIt == subscribers_.end()) {
+    return;
+  }
+  removeSubscriberIt(subIt, std::move(pubDone), "removeChannelSubscriber");
+}
+
+void MoQForwarder::removeChannelSubscriberByExec(
+    folly::Executor* exec,
+    std::optional<PublishDone> pubDone) {
+  const void* key = static_cast<const void*>(exec);
+  auto subIt = subscribers_.find(key);
+  if (subIt == subscribers_.end()) {
+    return;
+  }
+  removeSubscriberIt(subIt, std::move(pubDone), "removeChannelSubscriberByExec");
+}
+
 folly::Expected<SubscribeRange, FetchError> MoQForwarder::resolveJoiningFetch(
     const std::shared_ptr<MoQSession>& session,
     const JoiningFetch& joining) const {
-  auto subIt = subscribers_.find(session.get());
+  auto subIt = subscribers_.find(static_cast<const void*>(session.get()));
   if (subIt == subscribers_.end()) {
     XLOG(ERR) << "Session not found";
     return folly::makeUnexpected(
@@ -332,32 +414,8 @@ void MoQForwarder::drainSubscriber(
     const std::string& callsite) {
   XLOG(DBG1) << __func__ << " from " << callsite
              << " session=" << session.get();
-  auto subIt = subscribers_.find(session.get());
-  if (subIt == subscribers_.end()) {
-    XLOG(WARNING) << "Session not found in drainSubscriber from " << callsite
-                  << " sess=" << session;
-    return;
-  }
-
-  auto& subscriber = *subIt->second;
-
-  // Forward the publishDone message WITHOUT resetting subgroups
-  pubDone.requestID = subscriber.requestID;
-  if (subscriber.trackConsumer) {
-    subscriber.trackConsumer->publishDone(std::move(pubDone));
-  }
-
-  // If no open subgroups, delegate to removeSubscriberIt for cleanup
-  if (subscriber.subgroups.empty()) {
-    // Pass std::nullopt for pubDone since we already forwarded it above
-    removeSubscriberIt(subIt, std::nullopt, callsite);
-    return;
-  }
-
-  // Otherwise, mark receivedPublishDone and wait for subgroups to close
-  subscriber.receivedPublishDone_ = true;
-  XLOG(DBG1) << "Subscriber " << &subscriber << " is draining with "
-             << subscriber.subgroups.size() << " open subgroups";
+  drainSubscriberByKey(
+      static_cast<const void*>(session.get()), std::move(pubDone), callsite);
 }
 
 void MoQForwarder::removeSubscriber(
@@ -366,13 +424,8 @@ void MoQForwarder::removeSubscriber(
     const std::string& callsite) {
   XLOG(DBG1) << __func__ << " from " << callsite
              << " session=" << session.get();
-  auto subIt = subscribers_.find(session.get());
-  if (subIt == subscribers_.end()) {
-    XLOG(WARNING) << "Session not found in removeSubscriber from " << callsite
-                  << " sess=" << session;
-    return;
-  }
-  removeSubscriberIt(subIt, std::move(pubDone), callsite);
+  removeSubscriberByKey(
+      static_cast<const void*>(session.get()), std::move(pubDone), callsite);
 }
 
 void MoQForwarder::checkAndFireOnEmpty() {
@@ -388,7 +441,7 @@ void MoQForwarder::checkAndFireOnEmpty() {
 }
 
 void MoQForwarder::removeSubscriberIt(
-    folly::F14FastMap<MoQSession*, std::shared_ptr<Subscriber>>::iterator subIt,
+    folly::F14FastMap<const void*, std::shared_ptr<Subscriber>>::iterator subIt,
     std::optional<PublishDone> pubDone,
     const std::string& callsite) {
   auto& subscriber = *subIt->second;
@@ -420,6 +473,18 @@ void MoQForwarder::removeSubscriberIt(
   checkAndFireOnEmpty();
 }
 
+void MoQForwarder::removeSubscriberByKey(
+    const void* key,
+    std::optional<PublishDone> pubDone,
+    const std::string& callsite) {
+  auto subIt = subscribers_.find(key);
+  if (subIt == subscribers_.end()) {
+    XLOG(WARNING) << "Key not found in removeSubscriberByKey from " << callsite;
+    return;
+  }
+  removeSubscriberIt(subIt, std::move(pubDone), callsite);
+}
+
 void MoQForwarder::updateLargest(uint64_t group, uint64_t object) {
   AbsoluteLocation now{group, object};
   if (!largest_ || now > *largest_) {
@@ -446,8 +511,8 @@ bool MoQForwarder::checkPastEnd(const Subscriber& sub) {
   XCHECK(largest_);
   if (*largest_ > sub.range.end) {
     XLOG(DBG4) << "removeSubscriber from checkPastEnd";
-    removeSubscriber(
-        sub.session,
+    removeSubscriberByKey(
+        sub.mapKey,
         PublishDone{
             sub.requestID,
             PublishDoneStatusCode::SUBSCRIPTION_ENDED,
@@ -465,8 +530,8 @@ void MoQForwarder::removeSubscriberOnError(
     const std::string& callsite) {
   XLOG(ERR) << "Removing subscriber after error in " << callsite
             << " err=" << err.what();
-  removeSubscriber(
-      sub.session,
+  removeSubscriberByKey(
+      sub.mapKey,
       PublishDone{
           sub.requestID,
           PublishDoneStatusCode::INTERNAL_ERROR,
@@ -615,8 +680,8 @@ folly::Expected<folly::Unit, MoQPublishError> MoQForwarder::publishDone(
   XLOG(DBG1) << __func__ << " pubDone reason=" << pubDone.reasonPhrase;
   draining_ = true;
   forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
-    drainSubscriber(
-        sub->session,
+    drainSubscriberByKey(
+        sub->mapKey,
         PublishDone{
             sub->requestID,
             pubDone.statusCode,
@@ -787,7 +852,9 @@ MoQForwarder::Subscriber::requestUpdate(RequestUpdate requestUpdate) {
     if (*requestUpdate.endGroup > 0 && range.start >= newEnd) {
       XLOG(ERR) << "Invalid requestUpdate: end Location " << newEnd
                 << " is less than start " << range.start;
-      session->close(SessionCloseErrorCode::PROTOCOL_VIOLATION);
+      if (session) {
+        session->close(SessionCloseErrorCode::PROTOCOL_VIOLATION);
+      }
       co_return folly::makeUnexpected(RequestError(
           requestUpdate.requestID,
           RequestErrorCode::INVALID_RANGE,
@@ -808,8 +875,8 @@ MoQForwarder::Subscriber::requestUpdate(RequestUpdate requestUpdate) {
 }
 
 void MoQForwarder::Subscriber::unsubscribe() {
-  XLOG(DBG4) << "unsubscribe sess=" << this;
-  forwarder.removeSubscriber(session, std::nullopt, "unsubscribe");
+  XLOG(DBG4) << "unsubscribe key=" << mapKey;
+  forwarder.removeSubscriberByKey(mapKey, std::nullopt, "unsubscribe");
 }
 
 bool MoQForwarder::Subscriber::checkShouldForward() {
@@ -859,7 +926,7 @@ void MoQForwarder::SubgroupForwarder::closeSubgroupForSubscriber(
   sub->subgroups.erase(identifier_);
   // If this subscriber is draining and this was the last subgroup, remove it
   if (sub->shouldRemove()) {
-    forwarder_->removeSubscriber(sub->session, std::nullopt, callsite);
+    forwarder_->removeSubscriberByKey(sub->mapKey, std::nullopt, callsite);
   }
 }
 

--- a/moxygen/relay/MoQForwarder.h
+++ b/moxygen/relay/MoQForwarder.h
@@ -9,6 +9,7 @@
 #include "moxygen/MoQLocation.h"
 #include "moxygen/MoQSession.h"
 
+#include <folly/Executor.h>
 #include <folly/container/F14Set.h>
 #include <folly/hash/Hash.h>
 
@@ -135,6 +136,9 @@ class MoQForwarder : public TrackConsumer {
     }
 
     std::shared_ptr<MoQSession> session;
+    // Key used in MoQForwarder::subscribers_: session.get() for session
+    // subscribers, executor pointer for channel subscribers.
+    const void* mapKey{nullptr};
     RequestID requestID;
     SubscribeRange range;
     std::shared_ptr<TrackConsumer> trackConsumer;
@@ -164,7 +168,7 @@ class MoQForwarder : public TrackConsumer {
   }
 
   std::shared_ptr<Subscriber> getSubscriber(MoQSession* session) const {
-    auto it = subscribers_.find(session);
+    auto it = subscribers_.find(static_cast<const void*>(session));
     return it != subscribers_.end() ? it->second : nullptr;
   }
 
@@ -194,6 +198,26 @@ class MoQForwarder : public TrackConsumer {
       std::shared_ptr<TrackConsumer> consumer,
       bool passive = false);
 
+  // Add a channel subscriber: a cross-exec filter routing to a per-thread
+  // local forwarder.  `exec` is the subscriber iothread's executor — used as
+  // the unique map key so only one cross-exec filter per executor is added.
+  // Returns the Subscriber handle; call removeChannelSubscriber(handle) when
+  // the local forwarder drains.
+  std::shared_ptr<MoQForwarder::Subscriber> addChannelSubscriber(
+      folly::Executor* exec,
+      bool forward,
+      std::shared_ptr<TrackConsumer> consumer);
+
+  // Remove a channel subscriber added via addChannelSubscriber().
+  void removeChannelSubscriber(
+      const std::shared_ptr<MoQForwarder::Subscriber>& handle,
+      std::optional<PublishDone> pubDone = std::nullopt);
+
+  // Remove a channel subscriber by its executor key (avoids needing the handle).
+  void removeChannelSubscriberByExec(
+      folly::Executor* exec,
+      std::optional<PublishDone> pubDone = std::nullopt);
+
   folly::Expected<SubscribeRange, FetchError> resolveJoiningFetch(
       const std::shared_ptr<MoQSession>& session,
       const JoiningFetch& joining) const;
@@ -202,6 +226,13 @@ class MoQForwarder : public TrackConsumer {
   // open subgroups. Calls removeSubscriber() if no subgroups are open.
   void drainSubscriber(
       const std::shared_ptr<MoQSession>& session,
+      PublishDone pubDone,
+      const std::string& callsite);
+
+  // Same as drainSubscriber but looks up by mapKey rather than session pointer.
+  // Use this for channel subscribers (keyed by executor, session is null).
+  void drainSubscriberByKey(
+      const void* mapKey,
       PublishDone pubDone,
       const std::string& callsite);
 
@@ -353,8 +384,15 @@ class MoQForwarder : public TrackConsumer {
 
   // Helper that removes a subscriber given an iterator (avoids lookup)
   void removeSubscriberIt(
-      folly::F14FastMap<MoQSession*, std::shared_ptr<Subscriber>>::iterator
+      folly::F14FastMap<const void*, std::shared_ptr<Subscriber>>::iterator
           subIt,
+      std::optional<PublishDone> pubDone,
+      const std::string& callsite);
+
+  // Helper that looks up by mapKey and removes (used internally where a
+  // Subscriber reference is available but no session pointer)
+  void removeSubscriberByKey(
+      const void* key,
       std::optional<PublishDone> pubDone,
       const std::string& callsite);
 
@@ -370,7 +408,9 @@ class MoQForwarder : public TrackConsumer {
 
   FullTrackName fullTrackName_;
   std::optional<TrackAlias> trackAlias_;
-  folly::F14FastMap<MoQSession*, std::shared_ptr<Subscriber>> subscribers_;
+  // Keyed by const void*: session.get() for session subscribers,
+  // executor pointer for channel subscribers (cross-exec filters).
+  folly::F14FastMap<const void*, std::shared_ptr<Subscriber>> subscribers_;
   folly::F14FastMap<
       SubgroupIdentifier,
       std::shared_ptr<SubgroupForwarder>,

--- a/moxygen/relay/test/MoQForwarderTest.cpp
+++ b/moxygen/relay/test/MoQForwarderTest.cpp
@@ -18,6 +18,12 @@ using namespace moxygen;
 
 namespace moxygen::test {
 
+namespace {
+struct DummyExecutor : public folly::Executor {
+  void add(folly::Func) override {}
+};
+} // namespace
+
 const TrackNamespace kFwdTestNamespace{{"test", "namespace"}};
 const FullTrackName kFwdTestTrackName{kFwdTestNamespace, "track1"};
 
@@ -1184,6 +1190,189 @@ TEST_F(MoQForwarderTest, ForwardChangedFiresOnlyOnRealSubscriberTransitions) {
   forwarder->removeSubscriber(realSession2, std::nullopt, "test");
   EXPECT_EQ(cb->forwardChangedCalls, 1); // no additional forwardChanged
   EXPECT_EQ(cb->emptyCalls, 1);
+}
+
+// Test: addChannelSubscriber delivers subgroup objects to the channel consumer.
+TEST_F(MoQForwarderTest, ChannelSubscriberReceivesSubgroupObjects) {
+  auto forwarder = std::make_shared<MoQForwarder>(kFwdTestTrackName);
+  auto consumer = createMockConsumer();
+  DummyExecutor exec;
+
+  auto handle = forwarder->addChannelSubscriber(&exec, /*forward=*/true, consumer);
+  ASSERT_NE(handle, nullptr);
+  EXPECT_EQ(handle->session, nullptr);
+  EXPECT_EQ(forwarder->numForwardingSubscribers(), 1u);
+
+  std::shared_ptr<MockSubgroupConsumer> sg;
+  EXPECT_CALL(*consumer, beginSubgroup(0, 0, _, _))
+      .WillOnce([this, &sg](uint64_t, uint64_t, uint8_t, bool) {
+        sg = createMockSubgroupConsumer();
+        EXPECT_CALL(*sg, object(0, _, _, false)).WillOnce(Return(folly::unit));
+        EXPECT_CALL(*sg, endOfSubgroup()).WillOnce(Return(folly::unit));
+        return folly::
+            makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
+                sg);
+      });
+
+  auto sgRes = forwarder->beginSubgroup(0, 0, 0);
+  ASSERT_TRUE(sgRes.hasValue());
+  auto pubSg = *sgRes;
+  EXPECT_TRUE(pubSg->object(0, test::makeBuf(4)).hasValue());
+  EXPECT_TRUE(pubSg->endOfSubgroup().hasValue());
+}
+
+// Test: removeChannelSubscriber(handle) removes the subscriber.
+TEST_F(MoQForwarderTest, RemoveChannelSubscriberByHandle) {
+  auto forwarder = std::make_shared<MoQForwarder>(kFwdTestTrackName);
+  auto consumer = createMockConsumer();
+  DummyExecutor exec;
+
+  auto handle = forwarder->addChannelSubscriber(&exec, /*forward=*/true, consumer);
+  ASSERT_NE(handle, nullptr);
+  EXPECT_EQ(forwarder->subscriberCount(), 1u);
+  EXPECT_EQ(forwarder->numForwardingSubscribers(), 1u);
+
+  EXPECT_CALL(*consumer, publishDone(_))
+      .WillOnce(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+
+  forwarder->removeChannelSubscriber(
+      handle,
+      PublishDone{
+          RequestID(0),
+          PublishDoneStatusCode::SUBSCRIPTION_ENDED,
+          0,
+          ""});
+
+  EXPECT_TRUE(forwarder->empty());
+  EXPECT_EQ(forwarder->numForwardingSubscribers(), 0u);
+}
+
+// Test: removeChannelSubscriberByExec removes the subscriber by executor key.
+TEST_F(MoQForwarderTest, RemoveChannelSubscriberByExec) {
+  auto forwarder = std::make_shared<MoQForwarder>(kFwdTestTrackName);
+  auto consumer = createMockConsumer();
+  DummyExecutor exec;
+
+  auto handle = forwarder->addChannelSubscriber(&exec, /*forward=*/true, consumer);
+  ASSERT_NE(handle, nullptr);
+  EXPECT_EQ(forwarder->subscriberCount(), 1u);
+
+  forwarder->removeChannelSubscriberByExec(&exec, std::nullopt);
+  EXPECT_TRUE(forwarder->empty());
+}
+
+// Test: publishDone fans out to both session and channel subscribers.
+TEST_F(MoQForwarderTest, PublishDoneFansOutToMixedSubscribers) {
+  auto forwarder = std::make_shared<MoQForwarder>(kFwdTestTrackName);
+  auto sessionConsumer = createMockConsumer();
+  auto channelConsumer = createMockConsumer();
+  auto session = createMockSession();
+  DummyExecutor exec;
+
+  addSubscriber(*forwarder, session, sessionConsumer, RequestID(1));
+  forwarder->addChannelSubscriber(&exec, /*forward=*/true, channelConsumer);
+  EXPECT_EQ(forwarder->subscriberCount(), 2u);
+
+  EXPECT_CALL(*sessionConsumer, publishDone(_))
+      .WillOnce(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+  EXPECT_CALL(*channelConsumer, publishDone(_))
+      .WillOnce(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+
+  forwarder->publishDone(
+      PublishDone{
+          RequestID(0),
+          PublishDoneStatusCode::SUBSCRIPTION_ENDED,
+          0,
+          "done"});
+
+  EXPECT_TRUE(forwarder->empty());
+}
+
+// Test: duplicate addChannelSubscriber with the same exec is a no-op (returns
+// existing entry, forwarding count not double-incremented).
+TEST_F(MoQForwarderTest, DuplicateChannelSubscriberSameExecIsNoOp) {
+  auto forwarder = std::make_shared<MoQForwarder>(kFwdTestTrackName);
+  DummyExecutor exec;
+  auto consumer1 = createMockConsumer();
+  auto consumer2 = createMockConsumer();
+
+  auto handle1 = forwarder->addChannelSubscriber(&exec, /*forward=*/true, consumer1);
+  ASSERT_NE(handle1, nullptr);
+  EXPECT_EQ(forwarder->subscriberCount(), 1u);
+  EXPECT_EQ(forwarder->numForwardingSubscribers(), 1u);
+
+  // Same exec — emplace is a no-op, existing handle is returned.
+  auto handle2 = forwarder->addChannelSubscriber(&exec, /*forward=*/true, consumer2);
+  ASSERT_NE(handle2, nullptr);
+  EXPECT_EQ(handle1.get(), handle2.get());
+  EXPECT_EQ(forwarder->subscriberCount(), 1u);
+  EXPECT_EQ(forwarder->numForwardingSubscribers(), 1u);
+}
+
+// Test: channel subscriber drains gracefully when publishDone arrives with
+// open subgroups, then is removed when the last subgroup closes.
+TEST_F(MoQForwarderTest, ChannelSubscriberDrainsWhenSubgroupsOpen) {
+  auto forwarder = std::make_shared<MoQForwarder>(kFwdTestTrackName);
+  auto consumer = createMockConsumer();
+  DummyExecutor exec;
+
+  std::shared_ptr<MockSubgroupConsumer> sg;
+  EXPECT_CALL(*consumer, beginSubgroup(0, 0, _, _))
+      .WillOnce([this, &sg](uint64_t, uint64_t, uint8_t, bool) {
+        sg = createMockSubgroupConsumer();
+        return folly::
+            makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
+                sg);
+      });
+
+  forwarder->addChannelSubscriber(&exec, /*forward=*/true, consumer);
+  auto pubSg = forwarder->beginSubgroup(0, 0, 0).value();
+  ASSERT_TRUE(pubSg->beginObject(0, 10, 0).hasValue());
+
+  EXPECT_CALL(*consumer, publishDone(_))
+      .WillOnce(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+  EXPECT_CALL(*sg, reset(_)).Times(0);
+
+  forwarder->publishDone(
+      PublishDone{
+          RequestID(0), PublishDoneStatusCode::SUBSCRIPTION_ENDED, 0, ""});
+
+  // Subscriber draining but still present (open subgroup).
+  EXPECT_EQ(forwarder->subscriberCount(), 1u);
+
+  EXPECT_CALL(*sg, objectPayload(_, true));
+  EXPECT_TRUE(pubSg->objectPayload(test::makeBuf(10), true));
+
+  // Last subgroup closed — subscriber removed.
+  EXPECT_TRUE(forwarder->empty());
+}
+
+// Test: requestUpdate on a channel subscriber (null session) with an invalid
+// range does not crash.
+TEST_F(MoQForwarderTest, ChannelSubscriberRequestUpdateInvalidRangeNoCrash) {
+  auto forwarder = std::make_shared<MoQForwarder>(kFwdTestTrackName);
+  auto consumer = createMockConsumer();
+  DummyExecutor exec;
+
+  forwarder->setLargest({5, 0});
+  auto handle = forwarder->addChannelSubscriber(&exec, /*forward=*/true, consumer);
+  ASSERT_NE(handle, nullptr);
+
+  // endGroup=1 with range.start={0,0}: valid — should not crash.
+  RequestUpdate validUpdate;
+  validUpdate.requestID = RequestID(1);
+  validUpdate.endGroup = 10;
+  auto res1 = folly::coro::blockingWait(handle->requestUpdate(validUpdate));
+  EXPECT_TRUE(res1.hasValue());
+
+  // Set start ahead of a bounded end to trigger the invalid-range path, which
+  // calls session->close() — that must not crash when session is null.
+  RequestUpdate invalidUpdate;
+  invalidUpdate.requestID = RequestID(2);
+  invalidUpdate.start = AbsoluteLocation{20, 0}; // applied first, moves range.start
+  invalidUpdate.endGroup = 3; // endGroup=3 > 0, newEnd={3,0} < range.start={20,0}
+  auto res2 = folly::coro::blockingWait(handle->requestUpdate(invalidUpdate));
+  EXPECT_FALSE(res2.hasValue());
 }
 
 } // namespace moxygen::test


### PR DESCRIPTION
Add `addChannelSubscriber(Executor*, bool, shared_ptr<TrackConsumer>)` and `removeChannelSubscriber`/`removeChannelSubscriberByExec` for cross-exec fan-out.

Change `subscribers_` key from `MoQSession*` to `const void*` so both session subscribers (keyed by session.get()) and channel subscribers (keyed by executor pointer) share one map without a separate data structure. Add `Subscriber::mapKey` for self-removal via `unsubscribe()` and internal helpers. Add private `removeSubscriberByKey(const void*, ...)` used by `unsubscribe`, `checkPastEnd`, `removeSubscriberOnError`, and `closeSubgroupForSubscriber`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/215)
<!-- Reviewable:end -->
