### PR TITLE
moqtest: add latency measurement to perf client

### DIFF
--- a/moxygen/moqtest/MoQPerfTestClient.cpp
+++ b/moxygen/moqtest/MoQPerfTestClient.cpp
@@ -6,6 +6,7 @@
 
 #include "moxygen/moqtest/MoQPerfTestClient.h"
 
+#include <chrono>
 #include <folly/coro/Sleep.h>
 #include <folly/logging/xlog.h>
 #include "moxygen/MoQVersions.h"
@@ -202,6 +203,19 @@ ObjectReceiverCallback::FlowControlState SubscriberState::Callback::onObject(
   state_.objectsReceived_++;
   if (payload) {
     state_.bytesReceived_ += payload->computeChainDataLength();
+  }
+
+  if (auto sendTs = objHeader.extensions.getIntExtension(kTimestampExtensionType)) {
+    uint64_t nowMs =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count();
+    if (nowMs >= *sendTs) {
+      uint64_t latencyMs = nowMs - *sendTs;
+      state_.totalLatencyMs_ += latencyMs;
+      state_.latencyObjects_++;
+      state_.testClient_.recordLatency(latencyMs);
+    }
   }
 
   // Update largest object seen for track restart detection
@@ -440,6 +454,8 @@ void MoQPerfTestClient::removeSubscriber(size_t id) {
   // Add subscriber's stats to cumulative totals before removing
   cumulativeObjects_ += it->second->objectsReceived_;
   cumulativeBytes_ += it->second->bytesReceived_;
+  cumulativeLatencyMs_ += it->second->totalLatencyMs_;
+  cumulativeLatencyObjects_ += it->second->latencyObjects_;
 
   // Destructor will handle unsubscribe
   subscribers_.erase(it);
@@ -477,6 +493,23 @@ std::optional<AbsoluteLocation> MoQPerfTestClient::getLargestObjectSeen()
   return largestObjectSeen_;
 }
 
+void MoQPerfTestClient::recordLatency(uint64_t latencyMs) {
+  intervalLatencySum_.fetch_add(latencyMs, std::memory_order_relaxed);
+  intervalLatencyCount_.fetch_add(1, std::memory_order_relaxed);
+
+  uint64_t cur = intervalLatencyMin_.load(std::memory_order_relaxed);
+  while (latencyMs < cur &&
+         !intervalLatencyMin_.compare_exchange_weak(
+             cur, latencyMs, std::memory_order_relaxed)) {
+  }
+
+  cur = intervalLatencyMax_.load(std::memory_order_relaxed);
+  while (latencyMs > cur &&
+         !intervalLatencyMax_.compare_exchange_weak(
+             cur, latencyMs, std::memory_order_relaxed)) {
+  }
+}
+
 MoQPerfTestClient::TestResults MoQPerfTestClient::getResults() const {
   TestResults results;
   results.subscribersReached = peakSubscribers_.load();
@@ -488,11 +521,24 @@ MoQPerfTestClient::TestResults MoQPerfTestClient::getResults() const {
   // Combine cumulative stats with current active subscribers
   results.totalObjects = cumulativeObjects_.load();
   results.totalBytes = cumulativeBytes_.load();
+  results.totalLatencyMs = cumulativeLatencyMs_.load();
+  results.latencyObjects = cumulativeLatencyObjects_.load();
 
   for (const auto& [id, sub] : subscribers_) {
     results.totalObjects += sub->objectsReceived_;
     results.totalBytes += sub->bytesReceived_;
+    results.totalLatencyMs += sub->totalLatencyMs_;
+    results.latencyObjects += sub->latencyObjects_;
   }
+
+  results.intervalLatency.sumMs =
+      intervalLatencySum_.exchange(0, std::memory_order_relaxed);
+  results.intervalLatency.count =
+      intervalLatencyCount_.exchange(0, std::memory_order_relaxed);
+  results.intervalLatency.minMs = intervalLatencyMin_.exchange(
+      std::numeric_limits<uint64_t>::max(), std::memory_order_relaxed);
+  results.intervalLatency.maxMs =
+      intervalLatencyMax_.exchange(0, std::memory_order_relaxed);
 
   auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
                      std::chrono::steady_clock::now() - startTime_)

--- a/moxygen/moqtest/MoQPerfTestClient.h
+++ b/moxygen/moqtest/MoQPerfTestClient.h
@@ -54,6 +54,8 @@ class SubscriberState {
   size_t id_;
   uint64_t objectsReceived_{0};
   uint64_t bytesReceived_{0};
+  uint64_t totalLatencyMs_{0};
+  uint64_t latencyObjects_{0};
   bool hasError_{false};
 
  private:
@@ -113,6 +115,14 @@ class MoQPerfTestClient {
     size_t currentSubscribers{0}; // current active count
     uint64_t totalObjects{0};
     uint64_t totalBytes{0};
+    uint64_t totalLatencyMs{0};  // cumulative sum (for final avg)
+    uint64_t latencyObjects{0};  // cumulative count (for final avg)
+    struct IntervalLatency {
+      uint64_t sumMs{0};
+      uint64_t count{0};
+      uint64_t minMs{std::numeric_limits<uint64_t>::max()};
+      uint64_t maxMs{0};
+    } intervalLatency;
     uint32_t totalResets{0};
     uint32_t totalFailures{0};
     uint32_t durationSeconds{0};
@@ -127,6 +137,7 @@ class MoQPerfTestClient {
   void recordTrackRestart();
   void removeSubscriber(size_t id);
   void updateLargestObjectSeen(const AbsoluteLocation& location);
+  void recordLatency(uint64_t latencyMs);
   std::optional<AbsoluteLocation> getLargestObjectSeen() const;
 
  private:
@@ -164,6 +175,14 @@ class MoQPerfTestClient {
   std::atomic<uint32_t> numCompleted_{0};
   std::atomic<uint64_t> cumulativeObjects_{0};
   std::atomic<uint64_t> cumulativeBytes_{0};
+  std::atomic<uint64_t> cumulativeLatencyMs_{0};
+  std::atomic<uint64_t> cumulativeLatencyObjects_{0};
+  // Interval latency — reset on each getResults() call
+  mutable std::atomic<uint64_t> intervalLatencySum_{0};
+  mutable std::atomic<uint64_t> intervalLatencyCount_{0};
+  mutable std::atomic<uint64_t> intervalLatencyMin_{
+      std::numeric_limits<uint64_t>::max()};
+  mutable std::atomic<uint64_t> intervalLatencyMax_{0};
 };
 
 } // namespace moxygen

--- a/moxygen/moqtest/MoQPerfTestClientMain.cpp
+++ b/moxygen/moqtest/MoQPerfTestClientMain.cpp
@@ -77,10 +77,19 @@ folly::coro::Task<void> aggregateStats(
     uint32_t totalFailures = 0;
     uint32_t totalCompleted = 0;
 
+    uint64_t totalLatencyMs = 0;
+    uint64_t latencyObjects = 0;
+    moxygen::MoQPerfTestClient::TestResults::IntervalLatency ivl;
     for (const auto& client : clients) {
       auto results = client->getResults();
       totalObjects += results.totalObjects;
       totalBytes += results.totalBytes;
+      totalLatencyMs += results.totalLatencyMs;
+      latencyObjects += results.latencyObjects;
+      ivl.sumMs += results.intervalLatency.sumMs;
+      ivl.count += results.intervalLatency.count;
+      ivl.minMs = std::min(ivl.minMs, results.intervalLatency.minMs);
+      ivl.maxMs = std::max(ivl.maxMs, results.intervalLatency.maxMs);
       peakSubscribers += results.subscribersReached;
       currentSubscribers += results.currentSubscribers;
       totalResets += results.totalResets;
@@ -114,12 +123,24 @@ folly::coro::Task<void> aggregateStats(
     double mbps = (intervalBytes * 8.0) / (1024.0 * 1024.0);
     double totalMB = totalBytes / (1024.0 * 1024.0);
 
+    double runAvgLatencyMs =
+        latencyObjects > 0
+        ? static_cast<double>(totalLatencyMs) / static_cast<double>(latencyObjects)
+        : 0.0;
     XLOG(INFO) << "[AGGREGATE] [" << elapsed
                << "s] Subs: " << currentSubscribers
                << " | Obj/s: " << intervalObjects << " | Mbps: " << std::fixed
                << std::setprecision(2) << mbps << " | Total: " << totalObjects
                << " objs, " << std::fixed << std::setprecision(2) << totalMB
                << " MB"
+               << " | Latency(run avg): " << std::fixed << std::setprecision(1)
+               << runAvgLatencyMs << " ms"
+               << " | Latency(interval min/avg/max): "
+               << (ivl.count > 0 ? ivl.minMs : 0) << "/"
+               << std::fixed << std::setprecision(1)
+               << (ivl.count > 0 ? static_cast<double>(ivl.sumMs) /
+                       static_cast<double>(ivl.count) : 0.0)
+               << "/" << (ivl.count > 0 ? ivl.maxMs : 0) << " ms"
                << " | Resets: " << intervalResets << "/s, " << totalResets
                << " total"
                << " | Failures: " << intervalFailures << "/s, " << totalFailures
@@ -227,12 +248,16 @@ int main(int argc, char** argv) {
     XLOG(INFO) << "  Total Bytes: " << sharedStats->totalBytes.load();
     XLOG(INFO) << "  Total Resets: " << sharedStats->totalResets.load();
 
-    // Calculate aggregate throughput across all clients
+    // Calculate aggregate throughput and latency across all clients
     uint64_t totalBytes = 0;
+    uint64_t totalLatencyMs = 0;
+    uint64_t latencyObjects = 0;
 
     for (const auto& client : clients) {
       auto results = client->getResults();
       totalBytes += results.totalBytes;
+      totalLatencyMs += results.totalLatencyMs;
+      latencyObjects += results.latencyObjects;
     }
 
     auto duration = clients[0]->getResults().durationSeconds;
@@ -242,6 +267,13 @@ int main(int argc, char** argv) {
       double mbytes = static_cast<double>(totalBytes) / (1024.0 * 1024.0);
       double throughputMbps = (mbytes * 8.0) / static_cast<double>(duration);
       XLOG(INFO) << "  Throughput: " << throughputMbps << " Mbps";
+    }
+
+    if (latencyObjects > 0) {
+      double avgLatencyMs =
+          static_cast<double>(totalLatencyMs) / static_cast<double>(latencyObjects);
+      XLOG(INFO) << "  Avg Object Latency: " << avgLatencyMs << " ms ("
+                 << latencyObjects << " objects measured)";
     }
 
     if (sharedStats->trackEnded.load()) {

--- a/moxygen/moqtest/Utils.cpp
+++ b/moxygen/moqtest/Utils.cpp
@@ -6,6 +6,8 @@
 
 #include "moxygen/moqtest/Utils.h"
 
+#include <chrono>
+
 namespace moxygen {
 
 const int kNumParams = 16;
@@ -165,6 +167,11 @@ std::vector<Extension> getExtensions(
         static_cast<uint64_t>(2 * variableExtensionId + 1), {std::move(buf)}};
     extensions.push_back(ext);
   }
+  uint64_t timestampMs =
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::system_clock::now().time_since_epoch())
+          .count();
+  extensions.push_back(Extension{kTimestampExtensionType, timestampMs});
   return extensions;
 }
 

--- a/moxygen/moqtest/Utils.h
+++ b/moxygen/moqtest/Utils.h
@@ -10,6 +10,11 @@
 
 namespace moxygen {
 
+// Fixed extension type for the send timestamp (milliseconds since epoch).
+// Even type => integer extension. Value is large enough to avoid collision with
+// test integer extensions (which use 2 * testIntegerExtension).
+constexpr uint64_t kTimestampExtensionType = 0xC000;
+
 folly::Expected<folly::Unit, std::runtime_error> validateMoQTestParameters(
     const MoQTestParameters& track);
 


### PR DESCRIPTION
Server stamps each object with a millisecond epoch timestamp (kTimestampExtensionType = 0xC000) via getExtensions(). The perf client reads it on receipt and tracks latency two ways:

- Cumulative sum/count per subscriber (for final avg summary)
- Four atomics on MoQPerfTestClient (sum, count, min, max) updated per-object via recordLatency() and reset on each getResults() call, giving clean per-interval min/avg/max without data races

The periodic log shows a running avg and per-interval min/avg/max; the final summary shows the cumulative avg.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/219)
<!-- Reviewable:end -->
