### PR TITLE
moqtest: fix stat loss on teardown and interval underflow

### DIFF
--- a/moxygen/moqtest/MoQPerfTestClient.cpp
+++ b/moxygen/moqtest/MoQPerfTestClient.cpp
@@ -393,7 +393,11 @@ folly::coro::Task<void> MoQPerfTestClient::run() {
     XLOG(INFO) << "Test cancelled";
   }
 
-  // Clear all subscribers to trigger cleanup
+  // Flush active subscriber stats before clearing so getResults() stays accurate
+  for (auto& [id, sub] : subscribers_) {
+    cumulativeObjects_ += sub->objectsReceived_;
+    cumulativeBytes_ += sub->bytesReceived_;
+  }
   subscribers_.clear();
 }
 

--- a/moxygen/moqtest/MoQPerfTestClientMain.cpp
+++ b/moxygen/moqtest/MoQPerfTestClientMain.cpp
@@ -106,8 +106,10 @@ folly::coro::Task<void> aggregateStats(
     sharedStats->totalResets = totalResets;
 
     // Calculate interval stats
-    uint64_t intervalObjects = totalObjects - lastTotalObjects;
-    uint64_t intervalBytes = totalBytes - lastTotalBytes;
+    uint64_t intervalObjects =
+        totalObjects >= lastTotalObjects ? totalObjects - lastTotalObjects : 0;
+    uint64_t intervalBytes =
+        totalBytes >= lastTotalBytes ? totalBytes - lastTotalBytes : 0;
     uint32_t intervalResets = totalResets - lastTotalResets;
     uint32_t intervalFailures = totalFailures - lastTotalFailures;
 


### PR DESCRIPTION
Flush active subscriber counts into cumulativeObjects_/cumulativeBytes_ before clearing subscribers_ so getResults() sees accurate totals after the run ends. Guard interval deltas against underflow when stats temporarily decrease across aggregation ticks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/220)
<!-- Reviewable:end -->
