### PR TITLE
ci: add on-demand dev-build workflow for moxygen PR tarballs

### DIFF
--- a/.github/workflows/omoq-dev-build.yml
+++ b/.github/workflows/omoq-dev-build.yml
@@ -1,0 +1,82 @@
+name: dev build (manual)
+
+# Manual workflow that produces snapshot-equivalent moxygen tarballs from
+# any branch. Mirrors the publish job in omoq-ci-main.yml: same
+# BUNDLE_DEPS=ON / BUILD_TESTING=OFF / BUILD_SHARED_LIBS=OFF configure
+# flags, same collect-artifacts-standalone.sh packaging, same 90-day
+# actions-artifact retention.
+#
+# Triggered on-demand so PR branches can be validated end-to-end against
+# consumers (e.g. moqx) without waiting for the PR to merge into main and
+# the rolling snapshot release to regenerate.
+#
+# Strict isolation (mirrors moqx#315): no GHCR push, no release tag
+# promotion, no deploy. Pure kit producer.
+#
+# Usage:
+#   gh workflow run omoq-dev-build.yml --ref <branch> -f target=<target>
+#   gh run watch
+#   gh run download <run-id>
+#   tar -C <prefix> -xzf moxygen-dev-<target>-<sha>.tar.gz
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Build target platform'
+        type: choice
+        options:
+          - macos-15-arm64
+          - ubuntu-22.04-amd64
+        default: macos-15-arm64
+
+jobs:
+  build:
+    name: dev build (${{ inputs.target }})
+    runs-on: ${{ inputs.target == 'macos-15-arm64' && 'macos-15' || 'ubuntu-22.04' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system deps
+        run: bash standalone/install-system-deps.sh
+
+      - name: Configure
+        run: |
+          cmake -B _build -S standalone -G Ninja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DBUILD_TESTING=OFF \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DBUNDLE_DEPS=ON \
+            -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/install"
+
+      - name: Build
+        run: cmake --build _build -j$(getconf _NPROCESSORS_ONLN)
+
+      - name: Install
+        run: cmake --install _build
+
+      - name: Package
+        run: |
+          SHA_SHORT=$(git rev-parse --short HEAD)
+          ARTIFACT="moxygen-dev-${{ inputs.target }}-${SHA_SHORT}.tar.gz"
+          DEBUG_ARTIFACT="moxygen-dev-${{ inputs.target }}-${SHA_SHORT}-dbg.tar.gz"
+          bash openmoq/scripts/collect-artifacts-standalone.sh \
+            --install-prefix "$GITHUB_WORKSPACE/install" \
+            --output "$ARTIFACT" \
+            --debug-output "$DEBUG_ARTIFACT"
+          echo "ARTIFACT=$ARTIFACT" >> $GITHUB_ENV
+          echo "DEBUG_ARTIFACT=$DEBUG_ARTIFACT" >> $GITHUB_ENV
+
+      - name: Upload tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT }}
+          path: ${{ env.ARTIFACT }}
+          retention-days: 90
+
+      - name: Upload debug tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.DEBUG_ARTIFACT }}
+          path: ${{ env.DEBUG_ARTIFACT }}
+          retention-days: 90


### PR DESCRIPTION
## Summary

Adds a manual `workflow_dispatch` workflow that produces snapshot-equivalent moxygen tarballs from any branch — `macos-15-arm64` or `ubuntu-22.04-amd64`. Mirrors the `publish` job in [`omoq-ci-main.yml`](.github/workflows/omoq-ci-main.yml): same `BUNDLE_DEPS=ON` / `BUILD_TESTING=OFF` / `BUILD_SHARED_LIBS=OFF` configure flags, same `openmoq/scripts/collect-artifacts-standalone.sh` packaging, same 90-day actions-artifact retention.

Tarball shape matches release-snapshot artifacts byte for byte — same install-tree layout (`lib/cmake/{folly,proxygen,fizz,wangle,mvfst,moxygen}/`, all the `*-targets.cmake` exports), same compression, same naming convention. Just produced on-demand from any branch rather than after merge to main.

## Motivation

Validating a moxygen PR end-to-end against a consumer (notably [moqx](https://github.com/openmoq/moqx), whose `scripts/build.sh setup` fast path fetches the rolling snapshot tarball) today requires either:

1. Merging the PR into main and waiting for the snapshot to regenerate, then re-running the consumer.
2. Source-building moxygen from the PR branch on the consumer host directly. But that skips much of the release packaging (e.g. `BUNDLE_DEPS=ON` and the post-install collect-artifacts script), so the resulting install tree doesn't exercise the same shape end consumers see.

Neither matches "open a moxygen PR → hand someone a fresh kit to test on their machine in 10 minutes."

This workflow closes that gap.

## Behavior

- **Trigger**: `workflow_dispatch` only. No auto-triggers, no PR triggers, no push triggers.
- **Inputs**: `target` (choice between `macos-15-arm64` and `ubuntu-22.04-amd64`, default `macos-15-arm64`). Adding `bookworm-amd64` / `bookworm-arm64` is straightforward when needed.
- **Build**: `cmake -B _build -S standalone` with the release-equivalent flag set, `cmake --build`, `cmake --install`, `collect-artifacts-standalone.sh` → tarball + debug tarball.
- **Upload**: `actions/upload-artifact@v4`, 90-day retention.

## Isolation

Strict — mirrors [moqx#315](https://github.com/openmoq/moqx/pull/315)'s "kit-builder only" design:
- No GHCR push.
- No release tag promotion.
- No deploy.
- Separate workflow file (`omoq-dev-build.yml`) — doesn't touch `omoq-version-release.yml`, `omoq-ci-main.yml`, or anything else in the release / snapshot path.

## Use

```bash
gh workflow run omoq-dev-build.yml --ref <pr-branch> -f target=macos-15-arm64
gh run watch
gh run download <run-id>
# extract to the consumer's expected install prefix:
tar -C <consumer-repo>/.scratch/moxygen-install -xzf moxygen-dev-macos-15-arm64-<sha>.tar.gz
```

## Test plan

- [ ] Dispatch on this branch with `target=ubuntu-22.04-amd64`; confirm the workflow runs end-to-end and uploads a non-empty tarball.
- [ ] Dispatch on this branch with `target=macos-15-arm64`; same.
- [ ] Download the macOS tarball, extract into a moqx clone's `.scratch/moxygen-install`, confirm `bash scripts/build.sh` builds against it.
- [ ] Dispatch on a feature branch (e.g. `standalone/macos-stable-paths`) and confirm the resulting tarball reflects that branch's changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/223)
<!-- Reviewable:end -->
