### PR TITLE
relay: add passive subscriber flag to MoQForwarder

### DIFF
--- a/moxygen/relay/MoQForwarder.cpp
+++ b/moxygen/relay/MoQForwarder.cpp
@@ -241,6 +241,45 @@ std::shared_ptr<MoQForwarder::Subscriber> MoQForwarder::addSubscriber(
   return it->second;
 }
 
+std::shared_ptr<MoQForwarder::Subscriber> MoQForwarder::addSubscriber(
+    std::shared_ptr<MoQSession> session,
+    bool forward,
+    std::shared_ptr<TrackConsumer> consumer,
+    bool passive) {
+  if (draining_) {
+    XLOG(ERR) << "addSubscriber called on draining track";
+    return nullptr;
+  }
+  auto sessionPtr = session.get();
+  if (consumer && trackAlias_) {
+    consumer->setTrackAlias(*trackAlias_);
+  }
+  auto subscriber = std::make_shared<MoQForwarder::Subscriber>(
+      *this,
+      SubscribeOk{
+          RequestID(0),
+          trackAlias_.value_or(TrackAlias(0)),
+          std::chrono::milliseconds(0),
+          groupOrder_,
+          largest_,
+          extensions_},
+      std::move(session),
+      RequestID(0),
+      SubscribeRange{{0, 0}, kLocationMax},
+      std::move(consumer),
+      forward);
+  subscriber->passive = passive;
+  auto [it, inserted] = subscribers_.emplace(sessionPtr, subscriber);
+  if (inserted) {
+    if (passive) {
+      passiveCount_++;
+    } else if (forward) {
+      addForwardingSubscriber();
+    }
+  }
+  return it->second;
+}
+
 folly::Expected<SubscribeRange, FetchError> MoQForwarder::resolveJoiningFetch(
     const std::shared_ptr<MoQSession>& session,
     const JoiningFetch& joining) const {
@@ -337,7 +376,7 @@ void MoQForwarder::removeSubscriber(
 }
 
 void MoQForwarder::checkAndFireOnEmpty() {
-  if (subscribers_.empty()) {
+  if (subscribers_.size() == passiveCount_) {
     if (subgroups_.empty()) {
       if (callback_) {
         callback_->onEmpty(this);
@@ -365,9 +404,12 @@ void MoQForwarder::removeSubscriberIt(
     subscriber.trackConsumer->publishDone(std::move(*pubDone));
   }
 
-  if (subscriber.shouldForward) {
-    if (subscribers_.size() == 1) {
-      // don't trigger a forwardUpdated callback here, we will trigger onEmpty
+  if (subscriber.passive) {
+    passiveCount_--;
+  } else if (subscriber.shouldForward) {
+    if (subscribers_.size() == passiveCount_ + 1) {
+      // Last non-passive subscriber: onEmpty is about to fire, suppress
+      // the intermediate forwardChanged.
       forwardingSubscribers_--;
     } else {
       removeForwardingSubscriber();
@@ -695,6 +737,10 @@ void MoQForwarder::Subscriber::setParam(const TrackRequestParameter& param) {
 }
 
 void MoQForwarder::Subscriber::updateForwardState(bool newForward) {
+  if (passive) {
+    shouldForward = newForward;
+    return;
+  }
   auto wasForwarding = shouldForward;
   shouldForward = newForward;
   if (shouldForward && !wasForwarding) {

--- a/moxygen/relay/MoQForwarder.h
+++ b/moxygen/relay/MoQForwarder.h
@@ -148,6 +148,7 @@ class MoQForwarder : public TrackConsumer {
     }
 
     bool shouldForward;
+    bool passive{false};
     bool pinned{false};
     bool receivedPublishDone_{false};
 
@@ -181,6 +182,17 @@ class MoQForwarder : public TrackConsumer {
       const PublishRequest& pub) {
     return addSubscriber(std::move(session), pub.forward);
   }
+
+  // Add a subscriber with an explicit consumer and optional passive flag.
+  // Passive subscribers receive objects but do not count toward
+  // forwardingSubscribers_, so they do not affect the forwardChanged callback
+  // or onEmpty firing.  Use passive=true for internal consumers (e.g. cache)
+  // that should not influence the relay's upstream subscription lifecycle.
+  std::shared_ptr<MoQForwarder::Subscriber> addSubscriber(
+      std::shared_ptr<MoQSession> session,
+      bool forward,
+      std::shared_ptr<TrackConsumer> consumer,
+      bool passive = false);
 
   folly::Expected<SubscribeRange, FetchError> resolveJoiningFetch(
       const std::shared_ptr<MoQSession>& session,
@@ -377,6 +389,7 @@ class MoQForwarder : public TrackConsumer {
   void countReceivedObject(uint64_t groupID);
 
   uint64_t forwardingSubscribers_{0};
+  uint32_t passiveCount_{0};
   uint64_t totalGroupsReceived_{0};
   uint64_t totalObjectsReceived_{0};
   // NOTE: counts distinct group transitions, not distinct group IDs.

--- a/moxygen/relay/test/MoQForwarderTest.cpp
+++ b/moxygen/relay/test/MoQForwarderTest.cpp
@@ -1096,4 +1096,94 @@ TEST_F(MoQForwarderTest, SubscriberOnPublishOkDoesNotStrandPartialObject) {
           std::string(kObjectLength - kInitialLength, 'b'));
 }
 
+namespace {
+struct ForwardChangedTracker : public MoQForwarder::Callback {
+  void onEmpty(MoQForwarder*) override {
+    emptyCalls++;
+  }
+  void forwardChanged(MoQForwarder*) override {
+    forwardChangedCalls++;
+  }
+  int emptyCalls{0};
+  int forwardChangedCalls{0};
+};
+} // namespace
+
+// Test: passive subscriber does not trigger forwardChanged on add or remove.
+TEST_F(MoQForwarderTest, PassiveSubscriberDoesNotTriggerForwardChanged) {
+  auto forwarder = std::make_shared<MoQForwarder>(kFwdTestTrackName);
+  auto cb = std::make_shared<ForwardChangedTracker>();
+  forwarder->setCallback(cb);
+
+  auto session = createMockSession();
+  auto consumer = createMockConsumer();
+
+  // Adding a passive subscriber does not fire forwardChanged.
+  auto handle = forwarder->addSubscriber(session, /*forward=*/true, consumer, /*passive=*/true);
+  ASSERT_NE(handle, nullptr);
+  EXPECT_EQ(cb->forwardChangedCalls, 0);
+  EXPECT_EQ(forwarder->numForwardingSubscribers(), 0u);
+
+  // Removing the passive subscriber does not fire forwardChanged either.
+  forwarder->removeSubscriber(session, std::nullopt, "test");
+  EXPECT_EQ(cb->forwardChangedCalls, 0);
+}
+
+// Test: onEmpty fires when only passive subscribers remain (not when empty).
+TEST_F(MoQForwarderTest, OnEmptyFiresWhenOnlyPassiveRemain) {
+  auto forwarder = std::make_shared<MoQForwarder>(kFwdTestTrackName);
+  auto cb = std::make_shared<ForwardChangedTracker>();
+  forwarder->setCallback(cb);
+
+  auto realSession = createMockSession();
+  auto passiveSession = createMockSession();
+  auto realConsumer = createMockConsumer();
+  auto passiveConsumer = createMockConsumer();
+
+  forwarder->addSubscriber(realSession, /*forward=*/true, realConsumer);
+  forwarder->addSubscriber(passiveSession, /*forward=*/true, passiveConsumer, /*passive=*/true);
+
+  // Removing the real subscriber fires onEmpty (passive still attached).
+  forwarder->removeSubscriber(realSession, std::nullopt, "test");
+  EXPECT_EQ(cb->emptyCalls, 1);
+  // Forwarder is effectively empty (only passive remains) — passiveCount == subscribers.size().
+  EXPECT_EQ(forwarder->subscriberCount(), 1u);
+}
+
+// Test: mixed real+passive — forwardChanged fires only on real-subscriber transitions.
+TEST_F(MoQForwarderTest, ForwardChangedFiresOnlyOnRealSubscriberTransitions) {
+  auto forwarder = std::make_shared<MoQForwarder>(kFwdTestTrackName);
+  auto cb = std::make_shared<ForwardChangedTracker>();
+  forwarder->setCallback(cb);
+
+  auto realSession1 = createMockSession();
+  auto realSession2 = createMockSession();
+  auto passiveSession = createMockSession();
+  auto consumer = createMockConsumer();
+
+  // First real subscriber: forwardChanged fires (0→1).
+  forwarder->addSubscriber(realSession1, /*forward=*/true, consumer);
+  EXPECT_EQ(cb->forwardChangedCalls, 1);
+
+  // Passive subscriber: no forwardChanged.
+  forwarder->addSubscriber(passiveSession, /*forward=*/true, consumer, /*passive=*/true);
+  EXPECT_EQ(cb->forwardChangedCalls, 1);
+
+  // Second real subscriber: no forwardChanged (count stays > 0).
+  forwarder->addSubscriber(realSession2, /*forward=*/true, consumer);
+  EXPECT_EQ(cb->forwardChangedCalls, 1);
+  EXPECT_EQ(forwarder->numForwardingSubscribers(), 2u);
+
+  // Removing one real subscriber: no forwardChanged (still 1 left).
+  forwarder->removeSubscriber(realSession1, std::nullopt, "test");
+  EXPECT_EQ(cb->forwardChangedCalls, 1);
+  EXPECT_EQ(forwarder->numForwardingSubscribers(), 1u);
+
+  // Removing the last real subscriber fires onEmpty (passive still present)
+  // but NOT an intermediate forwardChanged.
+  forwarder->removeSubscriber(realSession2, std::nullopt, "test");
+  EXPECT_EQ(cb->forwardChangedCalls, 1); // no additional forwardChanged
+  EXPECT_EQ(cb->emptyCalls, 1);
+}
+
 } // namespace moxygen::test


### PR DESCRIPTION
MoQForwarder passive subscriber flag: add bool passive{false} to Subscriber and uint32_t passiveCount_{0} to MoQForwarder.  Passive subscribers receive objects (shouldForward=true) but are excluded from forwardingSubscribers_ accounting, so they do not trigger forwardChanged or suppress onEmpty.

Key invariant: onEmpty fires when subscribers_.size() == passiveCount_ — i.e., when all remaining subscribers are passive — not only when the map is fully empty.

The size guard in removeSubscriberIt changes from == 1 to == passiveCount_ + 1 so that removing the last non-passive subscriber correctly suppresses the intermediate forwardChanged before onEmpty fires.

Tests: passive add/remove does not fire forwardChanged; onEmpty fires when only passive remains; mixed real+passive transitions fire only on real subs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/228)
<!-- Reviewable:end -->
