### PR TITLE
install-system-deps: add brotli to macOS brew list

### DIFF
--- a/standalone/install-system-deps.sh
+++ b/standalone/install-system-deps.sh
@@ -76,7 +76,8 @@ install_macos() {
         boost \
         fmt \
         c-ares \
-        gperf
+        gperf \
+        brotli
 }
 
 # Detect OS - check macOS first


### PR DESCRIPTION
## Symptom

A new macOS developer who runs ``bash standalone/install-system-deps.sh`` and then ``bash scripts/build.sh`` (in a moqx clone whose moxygen submodule pulls this tree's tarball) gets a clean install + setup, then a hard linker error at the picoquic link step:

```
ld: warning: search path '/opt/homebrew/Cellar/brotli/1.2.0/lib' not found
ld: library 'brotlidec' not found
clang++: error: linker command failed with exit code 1
```

## Fix

Add ``brotli`` to the ``brew install`` list in ``install_macos``. One line.

## Why it wasn't caught in CI

GitHub's ``macos-15`` runner image ships ``brotli`` pre-installed, so the link step finds it without the install script needing to mention it. A fresh dev mac without ``brotli`` already brewed reproduces the failure deterministically.

## Why brotli is needed at all

The openmoq picoquic carry (``moxygen/openmoq/transport/pico``, openmoq-only — upstream FB has no picoquic) links against ``brotlidec`` / ``brotlienc`` / ``brotlicommon`` for HTTP/3 content encoding. ``picoquic-targets.cmake`` exports the brew Cellar lib path in ``INTERFACE_LINK_DIRECTORIES``, so consumers of the moxygen install tree need brotli to be present at the same path the snapshot was built against.

## Verified on

Apple Silicon macOS 15.7.2, AppleClang 17.0.0, brew 5.1.12 — clean dev host reproduces the original failure; ``brew install brotli`` followed by retry produces a green build (475/476 ctest, the one fail is the known-flaky ``relay_chain`` test, unrelated).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/231)
<!-- Reviewable:end -->
