### PR TITLE
install-system-deps: replace libboost-all-dev with specific components (Ubuntu/Debian)

### DIFF
--- a/standalone/install-system-deps.sh
+++ b/standalone/install-system-deps.sh
@@ -24,7 +24,12 @@ install_ubuntu() {
         libevent-dev \
         libsodium-dev \
         libzstd-dev \
-        libboost-all-dev \
+        libboost-dev \
+        libboost-context-dev \
+        libboost-filesystem-dev \
+        libboost-program-options-dev \
+        libboost-regex-dev \
+        libboost-thread-dev \
         libfmt-dev \
         zlib1g-dev \
         libc-ares-dev \


### PR DESCRIPTION
Closes #87.

## Problem

`standalone/install-system-deps.sh` installs `libboost-all-dev` on Ubuntu/Debian, which pulls in ~100 packages — MPI, OpenMPI, InfiniBand, graph-parallel, python, etc. — that the standalone build does not need. This adds several minutes to cold CI runs on GitHub-hosted runners.

## What we actually use

The standalone build (and o-rly) link these Boost components:
- `context`
- `filesystem`
- `program_options`
- `regex`
- `thread`

…plus headers-only Boost (`boost/optional.hpp` and friends, used by folly).

## Fix

Replace
```
libboost-all-dev
```
with
```
libboost-dev
libboost-context-dev
libboost-filesystem-dev
libboost-program-options-dev
libboost-regex-dev
libboost-thread-dev
```

(`libboost-dev` provides the header-only side of Boost; each `-component-dev` provides the corresponding `.so`/`.a`.)

## Why Fedora/macOS are untouched

- **Fedora**: `boost-devel` is already the conventional install on that distro — it doesn't pull the kitchen-sink the way Ubuntu's `libboost-all-dev` does.
- **macOS**: brew's `boost` is a single package that provides the components moxygen needs.

So this PR only changes the Ubuntu/Debian block.

## Verification

`apt-cache depends libboost-all-dev` on ubuntu-22.04 lists ~30 direct boost subpackage deps each with several transitive deps, totaling ~100 installed packages.
`apt-cache depends libboost-context-dev libboost-filesystem-dev libboost-program-options-dev libboost-regex-dev libboost-thread-dev libboost-dev` lists ~25 installed packages including their direct shared-library deps.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/233)
<!-- Reviewable:end -->
