### PR TITLE
install-system-deps: add python3 (fix bookworm publish jobs)

### DIFF
--- a/standalone/install-system-deps.sh
+++ b/standalone/install-system-deps.sh
@@ -33,6 +33,7 @@ install_ubuntu() {
         libfmt-dev \
         zlib1g-dev \
         libc-ares-dev \
+        python3 \
         gperf
 }
 
@@ -52,6 +53,7 @@ install_fedora() {
         fmt-devel \
         zlib-devel \
         c-ares-devel \
+        python3 \
         gperf
     # ninja-build is available on Fedora but not CentOS/RHEL base repos.
     # Try to install it; if unavailable, warn with alternatives.


### PR DESCRIPTION
## Problem

The `publish (bookworm-amd64)` and `publish (bookworm-arm64)` jobs fail at the **Configure** step:

\`\`\`
CMake Error at /cache/_deps/proxygen-src/CMakeLists.txt:66 (message):
  python is required for the proxygen build
\`\`\`

proxygen's configure runs `find_program(PROXYGEN_PYTHON python3)` and fatal-errors when no `python3` is on PATH. Until recently, `python3` arrived transitively via `libboost-all-dev`. Narrowing the install to the specific Boost components the build actually links (#233) dropped that transitive dependency.

The bookworm publish targets build inside a minimal `debian:bookworm` container whose base deps don't include python3, so Configure dies before the build starts. The hosted `ubuntu-22.04` runners ship python3 preinstalled, which is why they kept passing and masked the gap.

## Fix

Add `python3` explicitly to the Ubuntu/Debian and Fedora installs in `standalone/install-system-deps.sh`. It's a build-time tool requirement (alongside `gperf`, already present), not a runtime link dependency.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/243)
<!-- Reviewable:end -->
