### PR TITLE
MoQForwarder: add passive channel subscribers that don't gate forwarding

### DIFF
--- a/moxygen/relay/MoQForwarder.cpp
+++ b/moxygen/relay/MoQForwarder.cpp
@@ -290,7 +290,8 @@ std::shared_ptr<MoQForwarder::Subscriber> MoQForwarder::addSubscriber(
 std::shared_ptr<MoQForwarder::Subscriber> MoQForwarder::addChannelSubscriber(
     folly::Executor* exec,
     bool forward,
-    std::shared_ptr<TrackConsumer> consumer) {
+    std::shared_ptr<TrackConsumer> consumer,
+    bool passive) {
   if (draining_) {
     XLOG(ERR) << "addChannelSubscriber called on draining track";
     return nullptr;
@@ -313,10 +314,15 @@ std::shared_ptr<MoQForwarder::Subscriber> MoQForwarder::addChannelSubscriber(
       SubscribeRange{{0, 0}, kLocationMax},
       std::move(consumer),
       forward);
+  subscriber->passive = passive;
   subscriber->mapKey = key;
   auto [it, inserted] = subscribers_.emplace(key, subscriber);
-  if (inserted && forward) {
-    addForwardingSubscriber();
+  if (inserted) {
+    if (passive) {
+      passiveCount_++;
+    } else if (forward) {
+      addForwardingSubscriber();
+    }
   }
   return it->second;
 }
@@ -600,7 +606,15 @@ MoQForwarder::beginSubgroup(
       if (it != sub->subgroups.end() && it->second) {
         it->second->reset(ResetStreamErrorCode::CANCELLED);
         sub->subgroups.erase(it);
-        anyReset = true;
+        // Passive subscribers (e.g. the relay's own top-N/cache observer chain)
+        // are not real downstream consumers: they never stop_sending, so they
+        // must not mask the "no active consumers" signal. Reset their stale
+        // subgroup but do not count them toward anyReset, otherwise a duplicate
+        // subgroup would never propagate CANCELLED back to the publisher once
+        // all real consumers have stop_sent.
+        if (!sub->passive) {
+          anyReset = true;
+        }
       }
     }
     existingIt->second->detach();

--- a/moxygen/relay/MoQForwarder.h
+++ b/moxygen/relay/MoQForwarder.h
@@ -211,10 +211,17 @@ class MoQForwarder : public TrackConsumer {
   // the unique map key so only one cross-exec filter per executor is added.
   // Returns the Subscriber handle; call removeChannelSubscriber(handle) when
   // the local forwarder drains.
+  //
+  // passive=true marks the channel subscriber as not counting toward
+  // forwardingSubscribers_ or blocking onEmpty (see addSubscriber). Use it for
+  // the relay's own internal chain (top-N/termination/cache) attached below a
+  // local-forwarder primary, so the primary's onEmpty still fires once the last
+  // real cross-exec subscriber leaves.
   std::shared_ptr<MoQForwarder::Subscriber> addChannelSubscriber(
       folly::Executor* exec,
       bool forward,
-      std::shared_ptr<TrackConsumer> consumer);
+      std::shared_ptr<TrackConsumer> consumer,
+      bool passive = false);
 
   // Remove a channel subscriber added via addChannelSubscriber().
   void removeChannelSubscriber(


### PR DESCRIPTION

Summary:
Adds a `passive` flag to addChannelSubscriber() for the relay's own
internal observer chain (top-N / termination / cache) attached below a
local-forwarder primary. Passive subscribers are not real downstream
consumers, so they must not influence the forwarder's "are there active
consumers" accounting:

- They increment passiveCount_ instead of calling addForwardingSubscriber(),
  so they don't count toward forwardingSubscribers_ or block onEmpty. The
  primary's onEmpty still fires once the last real cross-exec subscriber
  leaves.
- In beginSubgroup(), resetting a passive subscriber's stale subgroup no
  longer sets anyReset. Passive subscribers never stop_sending, so counting
  them would mask the "no active consumers" signal and prevent a duplicate
  subgroup from propagating CANCELLED back to the publisher after all real
  consumers have stop_sent.

Test Plan:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/249)
<!-- Reviewable:end -->
