### PR TITLE
transport/pico: PicoQuicXLogSink — route picoquic internal logs through folly XLOG

### DIFF
--- a/moxygen/openmoq/transport/pico/CMakeLists.txt
+++ b/moxygen/openmoq/transport/pico/CMakeLists.txt
@@ -39,10 +39,9 @@ if(TARGET picohttp-core)
 endif()
 
 # XLog sink: routes picoquic's internal C-side log events into folly XLOG.
-# Implements a 4th picoquic_unified_logging_t and installs it via
-# quic->text_log_fns. Reaches into picoquic_internal.h (which is not in the
-# public install), so this target needs ${picoquic_SOURCE_DIR}/picoquic on
-# its include path — same trick openmoq_pico_base uses for picohttp headers.
+# Implements a 4th picoquic_unified_logging_t and installs it via picoquic's
+# public picoquic_set_unified_log_fns() setter (added by openmoq/picoquic#28).
+# No internal-header dependency.
 #
 # Opt-in: consumers call installPicoQuicXLogSink(quic) explicitly. Doesn't
 # alter any default-path behavior.
@@ -52,9 +51,9 @@ moxygen_add_library(openmoq_pico_xlog_sink
   EXPORTED_DEPS
     picoquic::picoquic-core
     Folly::folly_logging_logging
+    Folly::folly_range
+    Folly::folly_string
 )
-target_include_directories(openmoq_pico_xlog_sink PRIVATE
-  $<BUILD_INTERFACE:${picoquic_SOURCE_DIR}/picoquic>)
 
 # Shared server base: ALPN selection, picoCallback, per-connection context,
 # onNewConnectionImpl. Used by both the thread-based and EventBase servers.

--- a/moxygen/openmoq/transport/pico/CMakeLists.txt
+++ b/moxygen/openmoq/transport/pico/CMakeLists.txt
@@ -39,9 +39,8 @@ if(TARGET picohttp-core)
 endif()
 
 # XLog sink: routes picoquic's internal C-side log events into folly XLOG.
-# Implements a 4th picoquic_unified_logging_t and installs it via picoquic's
-# public picoquic_set_unified_log_fns() setter (added by openmoq/picoquic#28).
-# No internal-header dependency.
+# Implements a picoquic_unified_logging_t and registers it via picoquic's
+# generic picoquic_register_log_functions() API. No internal-header dependency.
 #
 # Opt-in: consumers call installPicoQuicXLogSink(quic) explicitly. Doesn't
 # alter any default-path behavior.

--- a/moxygen/openmoq/transport/pico/CMakeLists.txt
+++ b/moxygen/openmoq/transport/pico/CMakeLists.txt
@@ -38,6 +38,24 @@ if(TARGET picohttp-core)
   target_link_libraries(openmoq_pico_base PUBLIC picoquic::picohttp-core)
 endif()
 
+# XLog sink: routes picoquic's internal C-side log events into folly XLOG.
+# Implements a 4th picoquic_unified_logging_t and installs it via
+# quic->text_log_fns. Reaches into picoquic_internal.h (which is not in the
+# public install), so this target needs ${picoquic_SOURCE_DIR}/picoquic on
+# its include path — same trick openmoq_pico_base uses for picohttp headers.
+#
+# Opt-in: consumers call installPicoQuicXLogSink(quic) explicitly. Doesn't
+# alter any default-path behavior.
+moxygen_add_library(openmoq_pico_xlog_sink
+  SRCS
+    PicoQuicXLogSink.cpp
+  EXPORTED_DEPS
+    picoquic::picoquic-core
+    Folly::folly_logging_logging
+)
+target_include_directories(openmoq_pico_xlog_sink PRIVATE
+  $<BUILD_INTERFACE:${picoquic_SOURCE_DIR}/picoquic>)
+
 # Shared server base: ALPN selection, picoCallback, per-connection context,
 # onNewConnectionImpl. Used by both the thread-based and EventBase servers.
 moxygen_add_library(openmoq_pico_server_base

--- a/moxygen/openmoq/transport/pico/PicoQuicXLogSink.cpp
+++ b/moxygen/openmoq/transport/pico/PicoQuicXLogSink.cpp
@@ -17,7 +17,6 @@
 
 extern "C" {
 #include "picoquic.h"
-#include "picoquic_set_unified_log_fns.h"
 #include "picoquic_unified_log.h"
 }
 
@@ -63,9 +62,13 @@ std::string vformat(const char* fmt, va_list args) {
 }
 
 // ─── per-context callbacks ───────────────────────────────────────────────────
+// Each per-context callback receives `void* log_param` — the value passed to
+// picoquic_register_log_functions(). We pass nullptr (no per-quic state), so
+// log_param is unused.
 
 extern "C" void xlogLogQuicAppMessage(
     picoquic_quic_t* /*quic*/,
+    void* /*log_param*/,
     const picoquic_connection_id_t* cid,
     const char* fmt,
     va_list args) {
@@ -74,6 +77,7 @@ extern "C" void xlogLogQuicAppMessage(
 
 extern "C" void xlogLogQuicPdu(
     picoquic_quic_t* /*quic*/,
+    void* /*log_param*/,
     int receiving,
     uint64_t /*current_time*/,
     uint64_t cid64,
@@ -84,19 +88,31 @@ extern "C" void xlogLogQuicPdu(
              << "stray pdu len=" << packet_length;
 }
 
-extern "C" void xlogLogQuicClose(picoquic_quic_t* /*quic*/) {
+extern "C" void xlogLogQuicClose(
+    picoquic_quic_t* /*quic*/,
+    void* /*log_param*/) {
   // Nothing to release — the XLog sink owns no per-context state.
 }
 
 // ─── per-connection callbacks ────────────────────────────────────────────────
+// Each per-cnx callback receives `void* log_ctx` — the value xlogLogNewConnection
+// seeded into picoquic's per-cnx log_ctx slot. We currently set log_ctx to the
+// cnx pointer itself as a non-null sentinel (NULL would tell the dispatcher to
+// skip this cnx). A follow-up can attach per-cnx state (e.g. MoQ session-id
+// tagger) by allocating a small struct in xlogLogNewConnection and freeing it
+// in xlogLogCloseConnection.
 
-extern "C" void
-xlogLogAppMessage(picoquic_cnx_t* cnx, const char* fmt, va_list args) {
+extern "C" void xlogLogAppMessage(
+    picoquic_cnx_t* cnx,
+    void* /*log_ctx*/,
+    const char* fmt,
+    va_list args) {
   XLOG(INFO) << "[cnx=" << cnxShort(cnx) << "] " << vformat(fmt, args);
 }
 
 extern "C" void xlogLogPdu(
     picoquic_cnx_t* cnx,
+    void* /*log_ctx*/,
     int receiving,
     uint64_t /*current_time*/,
     const struct sockaddr* /*addr_peer*/,
@@ -110,6 +126,7 @@ extern "C" void xlogLogPdu(
 
 extern "C" void xlogLogPacket(
     picoquic_cnx_t* cnx,
+    void* /*log_ctx*/,
     picoquic_path_t* /*path*/,
     int receiving,
     uint64_t /*current_time*/,
@@ -122,6 +139,7 @@ extern "C" void xlogLogPacket(
 
 extern "C" void xlogLogDroppedPacket(
     picoquic_cnx_t* cnx,
+    void* /*log_ctx*/,
     picoquic_path_t* /*path*/,
     struct st_picoquic_packet_header_t* /*ph*/,
     size_t packet_size,
@@ -133,6 +151,7 @@ extern "C" void xlogLogDroppedPacket(
 
 extern "C" void xlogLogBufferedPacket(
     picoquic_cnx_t* cnx,
+    void* /*log_ctx*/,
     picoquic_path_t* /*path*/,
     picoquic_packet_type_enum ptype,
     uint64_t /*current_time*/) {
@@ -142,6 +161,7 @@ extern "C" void xlogLogBufferedPacket(
 
 extern "C" void xlogLogOutgoingPacket(
     picoquic_cnx_t* cnx,
+    void* /*log_ctx*/,
     picoquic_path_t* /*path*/,
     uint8_t* /*bytes*/,
     uint64_t sequence_number,
@@ -156,6 +176,7 @@ extern "C" void xlogLogOutgoingPacket(
 
 extern "C" void xlogLogPacketLost(
     picoquic_cnx_t* cnx,
+    void* /*log_ctx*/,
     picoquic_path_t* /*path*/,
     picoquic_packet_type_enum ptype,
     uint64_t sequence_number,
@@ -171,6 +192,7 @@ extern "C" void xlogLogPacketLost(
 
 extern "C" void xlogLogNegotiatedAlpn(
     picoquic_cnx_t* cnx,
+    void* /*log_ctx*/,
     int is_local,
     uint8_t const* sni,
     size_t sni_len,
@@ -191,6 +213,7 @@ extern "C" void xlogLogNegotiatedAlpn(
 
 extern "C" void xlogLogTransportExtension(
     picoquic_cnx_t* cnx,
+    void* /*log_ctx*/,
     int is_local,
     size_t param_length,
     uint8_t* /*params*/) {
@@ -201,22 +224,37 @@ extern "C" void xlogLogTransportExtension(
 
 extern "C" void xlogLogTlsTicket(
     picoquic_cnx_t* cnx,
+    void* /*log_ctx*/,
     uint8_t* /*ticket*/,
     uint16_t ticket_length) {
   XLOG(DBG2) << "[cnx=" << cnxShort(cnx) << "] "
              << "TLS ticket sz=" << ticket_length;
 }
 
-extern "C" void xlogLogNewConnection(picoquic_cnx_t* cnx) {
+// Lifecycle hook for seeding the per-cnx ctx. NULL *log_ctx tells picoquic's
+// dispatcher to skip every subsequent callback for this cnx — we opt in by
+// stashing a non-null sentinel (the cnx pointer itself).
+extern "C" void xlogLogNewConnection(
+    picoquic_cnx_t* cnx,
+    void* /*log_param*/,
+    void** log_ctx) {
+  if (log_ctx) {
+    *log_ctx = cnx;
+  }
   XLOG(DBG1) << "[cnx=" << cnxShort(cnx) << "] new connection";
 }
 
-extern "C" void xlogLogCloseConnection(picoquic_cnx_t* cnx) {
+extern "C" void xlogLogCloseConnection(
+    picoquic_cnx_t* cnx,
+    void* /*log_ctx*/) {
+  // No per-cnx allocation today, so nothing to free. If log_ctx becomes a
+  // heap-allocated state struct in the future, free it here.
   XLOG(DBG1) << "[cnx=" << cnxShort(cnx) << "] close connection";
 }
 
 extern "C" void xlogLogCcDump(
     picoquic_cnx_t* cnx,
+    void* /*log_ctx*/,
     picoquic_path_t* /*path*/,
     uint64_t /*current_time*/) {
   // Minimal cc-state snapshot. Detailed cc fields are accessible via opaque
@@ -227,9 +265,17 @@ extern "C" void xlogLogCcDump(
 
 // ─── the unified-logging struct (process-lifetime) ───────────────────────────
 
-// Non-const because picoquic_set_unified_log_fns() takes a non-const pointer
-// (matching its internal field type). Process-lifetime storage — never mutated
-// at runtime.
+// Non-const because picoquic_register_log_functions() takes a non-const
+// pointer (the runtime uses the address as a slot-lookup key for the
+// companion picoquic_get_log_params() getter). Process-lifetime storage —
+// never mutated at runtime.
+//
+// log_flush is intentionally nullptr: folly XLOG's async handler drains
+// continuously and sync_level=WARN already escalates important events to
+// synchronous emit on the calling thread. A process-wide LoggerDB flush at
+// every picoquic "sensitive event" call site would crater throughput for
+// negligible durability gain. picoquic's dispatcher gates on
+// (log_flush != NULL), so a null field is the explicit opt-out signal.
 picoquic_unified_logging_t kXLogBackend = {
     // Per-context functions
     .log_quic_app_message = xlogLogQuicAppMessage,
@@ -249,6 +295,7 @@ picoquic_unified_logging_t kXLogBackend = {
     .log_new_connection = xlogLogNewConnection,
     .log_close_connection = xlogLogCloseConnection,
     .log_cc_dump = xlogLogCcDump,
+    .log_flush = nullptr,
 };
 
 } // namespace
@@ -258,10 +305,11 @@ void installPicoQuicXLogSink(picoquic_quic_t* quic) {
     XLOG(ERR) << "installPicoQuicXLogSink: null quic context";
     return;
   }
-  // Install into the TEXT slot via picoquic's public setter (openmoq/picoquic
-  // landed picoquic_set_unified_log_fns()). Returns -1 only on null args, so
-  // success is guaranteed here given the early-return guard above.
-  picoquic_set_unified_log_fns(quic, PICOQUIC_LOG_SLOT_TEXT, &kXLogBackend);
+  // Register into the first free slot of picoquic's log-functions table.
+  // params=nullptr — this sink owns no per-quic state (logging config is
+  // global to folly's LoggerDB). Returns 0 on success, -1 on null args or
+  // full table.
+  picoquic_register_log_functions(quic, &kXLogBackend, /*params=*/nullptr);
 }
 
 } // namespace moxygen::openmoq::pico

--- a/moxygen/openmoq/transport/pico/PicoQuicXLogSink.cpp
+++ b/moxygen/openmoq/transport/pico/PicoQuicXLogSink.cpp
@@ -6,6 +6,8 @@
 
 #include "moxygen/openmoq/transport/pico/PicoQuicXLogSink.h"
 
+#include <folly/Range.h>
+#include <folly/String.h>
 #include <folly/logging/xlog.h>
 
 #include <cstdarg>
@@ -13,13 +15,9 @@
 #include <cstring>
 #include <string>
 
-// picoquic_internal.h is NOT installed publicly — we reach for it through the
-// picoquic source tree (CMake adds ${picoquic_SOURCE_DIR}/picoquic to our
-// include path). The slot we target is picoquic_quic_t::text_log_fns, defined
-// only in this internal header. Same trick picoquic's own qlog backend uses.
 extern "C" {
 #include "picoquic.h"
-#include "picoquic_internal.h"
+#include "picoquic_set_unified_log_fns.h"
 #include "picoquic_unified_log.h"
 }
 
@@ -33,14 +31,7 @@ std::string cidToHex(const picoquic_connection_id_t* cid) {
   if (!cid || cid->id_len == 0) {
     return "<empty>";
   }
-  static constexpr char kHex[] = "0123456789abcdef";
-  std::string out;
-  out.reserve(static_cast<size_t>(cid->id_len) * 2);
-  for (uint8_t i = 0; i < cid->id_len; ++i) {
-    out.push_back(kHex[(cid->id[i] >> 4) & 0x0f]);
-    out.push_back(kHex[cid->id[i] & 0x0f]);
-  }
-  return out;
+  return folly::hexlify(folly::ByteRange{cid->id, cid->id_len});
 }
 
 // Stable short connection identifier (first 8 hex chars of initial CID).
@@ -236,7 +227,10 @@ extern "C" void xlogLogCcDump(
 
 // ─── the unified-logging struct (process-lifetime) ───────────────────────────
 
-constexpr picoquic_unified_logging_t kXLogBackend = {
+// Non-const because picoquic_set_unified_log_fns() takes a non-const pointer
+// (matching its internal field type). Process-lifetime storage — never mutated
+// at runtime.
+picoquic_unified_logging_t kXLogBackend = {
     // Per-context functions
     .log_quic_app_message = xlogLogQuicAppMessage,
     .log_quic_pdu = xlogLogQuicPdu,
@@ -264,7 +258,10 @@ void installPicoQuicXLogSink(picoquic_quic_t* quic) {
     XLOG(ERR) << "installPicoQuicXLogSink: null quic context";
     return;
   }
-  quic->text_log_fns = const_cast<picoquic_unified_logging_t*>(&kXLogBackend);
+  // Install into the TEXT slot via picoquic's public setter (openmoq/picoquic
+  // landed picoquic_set_unified_log_fns()). Returns -1 only on null args, so
+  // success is guaranteed here given the early-return guard above.
+  picoquic_set_unified_log_fns(quic, PICOQUIC_LOG_SLOT_TEXT, &kXLogBackend);
 }
 
 } // namespace moxygen::openmoq::pico

--- a/moxygen/openmoq/transport/pico/PicoQuicXLogSink.cpp
+++ b/moxygen/openmoq/transport/pico/PicoQuicXLogSink.cpp
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "moxygen/openmoq/transport/pico/PicoQuicXLogSink.h"
+
+#include <folly/logging/xlog.h>
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+// picoquic_internal.h is NOT installed publicly — we reach for it through the
+// picoquic source tree (CMake adds ${picoquic_SOURCE_DIR}/picoquic to our
+// include path). The slot we target is picoquic_quic_t::text_log_fns, defined
+// only in this internal header. Same trick picoquic's own qlog backend uses.
+extern "C" {
+#include "picoquic.h"
+#include "picoquic_internal.h"
+#include "picoquic_unified_log.h"
+}
+
+namespace moxygen::openmoq::pico {
+namespace {
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+// Hex-encode a connection ID into a short string (for log line prefixes).
+std::string cidToHex(const picoquic_connection_id_t* cid) {
+  if (!cid || cid->id_len == 0) {
+    return "<empty>";
+  }
+  static constexpr char kHex[] = "0123456789abcdef";
+  std::string out;
+  out.reserve(static_cast<size_t>(cid->id_len) * 2);
+  for (uint8_t i = 0; i < cid->id_len; ++i) {
+    out.push_back(kHex[(cid->id[i] >> 4) & 0x0f]);
+    out.push_back(kHex[cid->id[i] & 0x0f]);
+  }
+  return out;
+}
+
+// Stable short connection identifier (first 8 hex chars of initial CID).
+std::string cnxShort(picoquic_cnx_t* cnx) {
+  if (!cnx) {
+    return "<null>";
+  }
+  picoquic_connection_id_t cid = picoquic_get_initial_cnxid(cnx);
+  std::string hex = cidToHex(&cid);
+  return hex.size() > 8 ? hex.substr(0, 8) : hex;
+}
+
+// Format a printf-style message into a stack buffer; safe for log lines.
+// Truncates with "..." if the message is longer than the buffer.
+std::string vformat(const char* fmt, va_list args) {
+  char buf[1024];
+  int n = vsnprintf(buf, sizeof(buf), fmt, args);
+  if (n <= 0) {
+    return {};
+  }
+  if (static_cast<size_t>(n) >= sizeof(buf)) {
+    constexpr const char kEllipsis[] = "...";
+    constexpr size_t kEllipsisLen = sizeof(kEllipsis) - 1;
+    memcpy(buf + sizeof(buf) - kEllipsisLen - 1, kEllipsis, kEllipsisLen);
+    buf[sizeof(buf) - 1] = '\0';
+    return buf;
+  }
+  return {buf, static_cast<size_t>(n)};
+}
+
+// ─── per-context callbacks ───────────────────────────────────────────────────
+
+extern "C" void xlogLogQuicAppMessage(
+    picoquic_quic_t* /*quic*/,
+    const picoquic_connection_id_t* cid,
+    const char* fmt,
+    va_list args) {
+  XLOG(INFO) << "[cid=" << cidToHex(cid) << "] " << vformat(fmt, args);
+}
+
+extern "C" void xlogLogQuicPdu(
+    picoquic_quic_t* /*quic*/,
+    int receiving,
+    uint64_t /*current_time*/,
+    uint64_t cid64,
+    const struct sockaddr* /*addr_peer*/,
+    const struct sockaddr* /*addr_local*/,
+    size_t packet_length) {
+  XLOG(DBG3) << "[cid64=" << cid64 << "] " << (receiving ? "<- " : "-> ")
+             << "stray pdu len=" << packet_length;
+}
+
+extern "C" void xlogLogQuicClose(picoquic_quic_t* /*quic*/) {
+  // Nothing to release — the XLog sink owns no per-context state.
+}
+
+// ─── per-connection callbacks ────────────────────────────────────────────────
+
+extern "C" void
+xlogLogAppMessage(picoquic_cnx_t* cnx, const char* fmt, va_list args) {
+  XLOG(INFO) << "[cnx=" << cnxShort(cnx) << "] " << vformat(fmt, args);
+}
+
+extern "C" void xlogLogPdu(
+    picoquic_cnx_t* cnx,
+    int receiving,
+    uint64_t /*current_time*/,
+    const struct sockaddr* /*addr_peer*/,
+    const struct sockaddr* /*addr_local*/,
+    size_t packet_length,
+    uint64_t /*unique_path_id*/,
+    unsigned char /*ecn*/) {
+  XLOG(DBG3) << "[cnx=" << cnxShort(cnx) << "] " << (receiving ? "<- " : "-> ")
+             << "pdu len=" << packet_length;
+}
+
+extern "C" void xlogLogPacket(
+    picoquic_cnx_t* cnx,
+    picoquic_path_t* /*path*/,
+    int receiving,
+    uint64_t /*current_time*/,
+    struct st_picoquic_packet_header_t* /*ph*/,
+    const uint8_t* /*bytes*/,
+    size_t bytes_max) {
+  XLOG(DBG3) << "[cnx=" << cnxShort(cnx) << "] " << (receiving ? "<- " : "-> ")
+             << "pkt len=" << bytes_max;
+}
+
+extern "C" void xlogLogDroppedPacket(
+    picoquic_cnx_t* cnx,
+    picoquic_path_t* /*path*/,
+    struct st_picoquic_packet_header_t* /*ph*/,
+    size_t packet_size,
+    int err,
+    uint64_t /*current_time*/) {
+  XLOG(DBG1) << "[cnx=" << cnxShort(cnx) << "] "
+             << "dropped pkt size=" << packet_size << " err=" << err;
+}
+
+extern "C" void xlogLogBufferedPacket(
+    picoquic_cnx_t* cnx,
+    picoquic_path_t* /*path*/,
+    picoquic_packet_type_enum ptype,
+    uint64_t /*current_time*/) {
+  XLOG(DBG2) << "[cnx=" << cnxShort(cnx) << "] "
+             << "buffered pkt type=" << static_cast<int>(ptype);
+}
+
+extern "C" void xlogLogOutgoingPacket(
+    picoquic_cnx_t* cnx,
+    picoquic_path_t* /*path*/,
+    uint8_t* /*bytes*/,
+    uint64_t sequence_number,
+    size_t /*pn_length*/,
+    size_t length,
+    uint8_t* /*send_buffer*/,
+    size_t /*send_length*/,
+    uint64_t /*current_time*/) {
+  XLOG(DBG3) << "[cnx=" << cnxShort(cnx) << "] "
+             << "out pkt seq=" << sequence_number << " len=" << length;
+}
+
+extern "C" void xlogLogPacketLost(
+    picoquic_cnx_t* cnx,
+    picoquic_path_t* /*path*/,
+    picoquic_packet_type_enum ptype,
+    uint64_t sequence_number,
+    char const* trigger,
+    picoquic_connection_id_t* /*dcid*/,
+    size_t packet_size,
+    uint64_t /*current_time*/) {
+  XLOG(DBG1) << "[cnx=" << cnxShort(cnx) << "] "
+             << "lost pkt type=" << static_cast<int>(ptype)
+             << " seq=" << sequence_number << " sz=" << packet_size
+             << " trigger=" << (trigger ? trigger : "?");
+}
+
+extern "C" void xlogLogNegotiatedAlpn(
+    picoquic_cnx_t* cnx,
+    int is_local,
+    uint8_t const* sni,
+    size_t sni_len,
+    uint8_t const* alpn,
+    size_t alpn_len,
+    const ptls_iovec_t* /*alpn_list*/,
+    size_t /*alpn_count*/) {
+  std::string sniStr = (sni && sni_len > 0)
+      ? std::string(reinterpret_cast<const char*>(sni), sni_len)
+      : "";
+  std::string alpnStr = (alpn && alpn_len > 0)
+      ? std::string(reinterpret_cast<const char*>(alpn), alpn_len)
+      : "";
+  XLOG(DBG1) << "[cnx=" << cnxShort(cnx) << "] "
+             << "ALPN negotiated (is_local=" << is_local << " sni=" << sniStr
+             << " alpn=" << alpnStr << ")";
+}
+
+extern "C" void xlogLogTransportExtension(
+    picoquic_cnx_t* cnx,
+    int is_local,
+    size_t param_length,
+    uint8_t* /*params*/) {
+  XLOG(DBG2) << "[cnx=" << cnxShort(cnx) << "] "
+             << "transport extension is_local=" << is_local
+             << " param_len=" << param_length;
+}
+
+extern "C" void xlogLogTlsTicket(
+    picoquic_cnx_t* cnx,
+    uint8_t* /*ticket*/,
+    uint16_t ticket_length) {
+  XLOG(DBG2) << "[cnx=" << cnxShort(cnx) << "] "
+             << "TLS ticket sz=" << ticket_length;
+}
+
+extern "C" void xlogLogNewConnection(picoquic_cnx_t* cnx) {
+  XLOG(DBG1) << "[cnx=" << cnxShort(cnx) << "] new connection";
+}
+
+extern "C" void xlogLogCloseConnection(picoquic_cnx_t* cnx) {
+  XLOG(DBG1) << "[cnx=" << cnxShort(cnx) << "] close connection";
+}
+
+extern "C" void xlogLogCcDump(
+    picoquic_cnx_t* cnx,
+    picoquic_path_t* /*path*/,
+    uint64_t /*current_time*/) {
+  // Minimal cc-state snapshot. Detailed cc fields are accessible via opaque
+  // path/cnx getters; a follow-up can extend this to include rtt, cwnd,
+  // ssthresh once we decide which getters are stable across picoquic versions.
+  XLOG(DBG2) << "[cnx=" << cnxShort(cnx) << "] cc snapshot";
+}
+
+// ─── the unified-logging struct (process-lifetime) ───────────────────────────
+
+constexpr picoquic_unified_logging_t kXLogBackend = {
+    // Per-context functions
+    .log_quic_app_message = xlogLogQuicAppMessage,
+    .log_quic_pdu = xlogLogQuicPdu,
+    .log_quic_close = xlogLogQuicClose,
+    // Per-connection functions
+    .log_app_message = xlogLogAppMessage,
+    .log_pdu = xlogLogPdu,
+    .log_packet = xlogLogPacket,
+    .log_dropped_packet = xlogLogDroppedPacket,
+    .log_buffered_packet = xlogLogBufferedPacket,
+    .log_outgoing_packet = xlogLogOutgoingPacket,
+    .log_packet_lost = xlogLogPacketLost,
+    .log_negotiated_alpn = xlogLogNegotiatedAlpn,
+    .log_transport_extension = xlogLogTransportExtension,
+    .log_picotls_ticket = xlogLogTlsTicket,
+    .log_new_connection = xlogLogNewConnection,
+    .log_close_connection = xlogLogCloseConnection,
+    .log_cc_dump = xlogLogCcDump,
+};
+
+} // namespace
+
+void installPicoQuicXLogSink(picoquic_quic_t* quic) {
+  if (!quic) {
+    XLOG(ERR) << "installPicoQuicXLogSink: null quic context";
+    return;
+  }
+  quic->text_log_fns = const_cast<picoquic_unified_logging_t*>(&kXLogBackend);
+}
+
+} // namespace moxygen::openmoq::pico

--- a/moxygen/openmoq/transport/pico/PicoQuicXLogSink.h
+++ b/moxygen/openmoq/transport/pico/PicoQuicXLogSink.h
@@ -14,21 +14,22 @@ typedef struct st_picoquic_quic_t picoquic_quic_t;
 namespace moxygen::openmoq::pico {
 
 /**
- * Install a folly XLOG sink as picoquic's text-log backend on the given quic
- * context. After this call, picoquic's internal log events (per-packet, per-cnx
- * lifecycle, drops, losses, CC dumps, ALPN negotiation, etc.) are dispatched
- * through folly's LoggerDB and governed by the standard --logging=... config
- * string under the `quic.picoquic.*` category root.
+ * Install a folly XLOG sink on the given picoquic context. After this call,
+ * picoquic's internal log events (per-packet, per-cnx lifecycle, drops, losses,
+ * CC dumps, ALPN negotiation, etc.) are dispatched through folly's LoggerDB
+ * and governed by the standard --logging=... config string under the
+ * `quic.picoquic.*` category root.
  *
- * Mutually exclusive with picoquic_set_textlog() — both target the same slot
- * (picoquic_quic_t::text_log_fns). qlog (picoquic_set_qlog) is unaffected and
- * can run in parallel as a separate channel; binlog (picoquic_set_binlog) the
- * same.
+ * Coexists with picoquic's builtin loggers (picoquic_set_textlog,
+ * picoquic_set_binlog, picoquic_set_qlog). picoquic dispatches each event to
+ * every registered logger in its log-functions table; the XLog sink takes one
+ * of three slots and runs in parallel with whichever builtins the application
+ * also enabled. Typical moqx usage enables only the XLog sink and skips the
+ * builtins entirely.
  *
  * The sink is registered with a static struct that has process-lifetime
- * storage, so this function may be called multiple times safely. To
- * uninstall, set quic->text_log_fns = nullptr through whatever API picoquic
- * provides (typically picoquic_textlog_close).
+ * storage, so this function may be called multiple times safely (subsequent
+ * calls are no-ops once the slot is taken).
  *
  * Severity mapping summary:
  *   INFO    — app_message hooks (deliberate app-level logs)

--- a/moxygen/openmoq/transport/pico/PicoQuicXLogSink.h
+++ b/moxygen/openmoq/transport/pico/PicoQuicXLogSink.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// Forward-decl to keep this header light. The C type comes from picoquic.h.
+extern "C" {
+typedef struct st_picoquic_quic_t picoquic_quic_t;
+}
+
+namespace moxygen::openmoq::pico {
+
+/**
+ * Install a folly XLOG sink as picoquic's text-log backend on the given quic
+ * context. After this call, picoquic's internal log events (per-packet, per-cnx
+ * lifecycle, drops, losses, CC dumps, ALPN negotiation, etc.) are dispatched
+ * through folly's LoggerDB and governed by the standard --logging=... config
+ * string under the `quic.picoquic.*` category root.
+ *
+ * Mutually exclusive with picoquic_set_textlog() — both target the same slot
+ * (picoquic_quic_t::text_log_fns). qlog (picoquic_set_qlog) is unaffected and
+ * can run in parallel as a separate channel; binlog (picoquic_set_binlog) the
+ * same.
+ *
+ * The sink is registered with a static struct that has process-lifetime
+ * storage, so this function may be called multiple times safely. To
+ * uninstall, set quic->text_log_fns = nullptr through whatever API picoquic
+ * provides (typically picoquic_textlog_close).
+ *
+ * Severity mapping summary:
+ *   INFO    — app_message hooks (deliberate app-level logs)
+ *   DBG1    — connection lifecycle, ALPN, drops, losses
+ *   DBG2    — transport params, TLS ticket, CC dump
+ *   DBG3    — per-packet (pdu in/out, decrypted packet, outgoing packet)
+ *
+ * Operators target the bridge via the standard XLOG config:
+ *   --logging=quic.picoquic=INFO         // lifecycle + app msgs
+ *   --logging=quic.picoquic=DBG1         // adds drops/losses
+ *   --logging=quic.picoquic=DBG3         // adds per-packet firehose
+ *
+ * @param quic  the picoquic context to install the sink on. Must be non-null.
+ */
+void installPicoQuicXLogSink(picoquic_quic_t* quic);
+
+} // namespace moxygen::openmoq::pico


### PR DESCRIPTION
## Summary

PoC bringing picoquic's internal C-side logging into the unified folly XLOG story (openmoq/moqx#339), so the picoquic stack participates on equal footing with mvfst once the rest of the normalization lands.

The C++ wrapper at `moxygen/openmoq/transport/pico/` already uses `XLOG(...)` natively. What was missing was a route for picoquic's **internal C-side events** (per-packet, per-cnx lifecycle, drops, losses, CC, ALPN, etc.) — those flow through picoquic's `picoquic_unified_logging_t` abstraction and currently can only be written to text/bin/qlog **files**, separate from the operator's `--logging=` knob.

This PR adds a **4th implementation** of that struct that emits `XLOG(...)` instead of writing to a file, plus an opt-in installer.

## How it plugs in

Picoquic stores three pointers (`text_log_fns`, `bin_log_fns`, `qlog_fns`) in `picoquic_quic_t`, one per output mode. Existing setters wire them up via direct assignment, e.g. from `loglib/qlog_fns.c`:

```c
int picoquic_set_qlog(picoquic_quic_t* quic, char const* qlog_dir) {
    quic->qlog_fns = &qlog_fns;
    ...
}
```

`PicoQuicXLogSink` mirrors that exactly:

```cpp
void installPicoQuicXLogSink(picoquic_quic_t* quic) {
    quic->text_log_fns = const_cast<picoquic_unified_logging_t*>(&kXLogBackend);
}
```

`kXLogBackend` is a process-lifetime constant struct whose 14 fields point at `extern "C"` callbacks defined in the file. Each formats its event into a `XLOG(...)` line with the appropriate severity.

## Severity mapping

| event class | level |
|---|---|
| `log_app_message` / `log_quic_app_message` | `INFO` |
| `log_new_connection` / `log_close_connection` / `log_negotiated_alpn` | `DBG1` |
| `log_dropped_packet` / `log_buffered_packet` / `log_packet_lost` | `DBG1` |
| `log_transport_extension` / `log_picotls_ticket` / `log_cc_dump` | `DBG2` |
| `log_pdu` / `log_packet` / `log_outgoing_packet` (per-packet) | `DBG3` |
| `log_quic_close` | no emit (just cleanup) |

Operator UX:
- `--logging=quic.picoquic=INFO` → lifecycle + app messages
- `--logging=quic.picoquic=DBG1` → adds drops, losses, buffered events
- `--logging=quic.picoquic=DBG3` → opens the per-packet firehose

(Category root depends on where Alan lands the `quic.{mvfst,picoquic}` discussion in #339; this PR doesn't pick it — categories derive from `__FILE__` per the standard `FOLLY_XLOG_STRIP_PREFIXES` mechanism.)

## Internal-header dependency

Reaches into `picoquic_internal.h` to write the `text_log_fns` slot — the same access pattern picoquic's own qlog backend uses. The CMake target gets `${picoquic_SOURCE_DIR}/picoquic` on its include path via the BUILD_INTERFACE trick already used for picohttp.

If reviewers prefer a public picoquic API, follow-up could add `picoquic_set_unified_log(quic, fns)` to openmoq/picoquic — small patch.

## Interaction with qlog/binlog

- **Mutually exclusive with `picoquic_set_textlog`** — same slot (`text_log_fns`). Users running an XLog sink should not call `picoquic_set_textlog`.
- **qlog and binlog are independent** — different slots; can be enabled in parallel via `picoquic_set_qlog(quic, dir)` / `picoquic_set_binlog(quic, dir)`. The intended split:
  - daily ops / dev debugging → XLog (`--logging=quic.picoquic=DBG2`)
  - deep packet analysis → qlog (separate `--qlog-dir` flag, consumed by qvis)

## Opt-in only

Nothing in the existing transport/server init paths is changed. Consumers (`MoQPicoQuicServer`, `MoQPicoQuicEventBaseServer`, etc.) that want the sink call `installPicoQuicXLogSink(quic)` after creating their picoquic context. Default behavior is unchanged.

## Test plan

- [ ] Standalone build (`-DBUILD_PICOQUIC=ON`) compiles the new `openmoq_pico_xlog_sink` target.
- [ ] Wire up an experimental call site (e.g. in a sample) and verify events flow:
  - `--logging=.=INFO` shows connection-establish and ALPN lines
  - `--logging=quic.picoquic=DBG3` shows per-packet output
  - `--logging=quic.picoquic=WARN` is quiet during steady state
- [ ] Run alongside `picoquic_set_qlog(quic, "/tmp/qlogs")` — confirm qlog files still written; XLog sink output also appears in stderr.
- [ ] Throughput: perf-test with XLog sink installed at `DBG1` — no regression vs sink-not-installed baseline (async folly LoggerDB should absorb).

## Refs

- Design doc: `notes/picoquic-logging-bridge.md` (in openmoq/notes/)
- Test plan: `notes/logging-test-plan.md` (Gate 2 covers `quic.picoquic.*`)
- Master spec: openmoq/moqx#339

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/256)
<!-- Reviewable:end -->
