### PR TITLE
Remove CODEOWNERS (advisory-only, no merge gating)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -50,9 +50,8 @@ maintainer unblocks them; subsequent runs are automatic.
 
 ## Reviews
 
-At least one approving review from a collaborator is required.
-[CODEOWNERS](CODEOWNERS) auto-requests reviewers. Review on GitHub or
-[Reviewable](https://reviewable.io/reviews/openmoq/moxygen).
+At least one approving review from a collaborator is required. Review
+on GitHub or [Reviewable](https://reviewable.io/reviews/openmoq/moxygen).
 
 **Admin override** (`gh pr merge --admin`) is for:
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,0 @@
-# CODEOWNERS — auto-requests reviews from the openmoq merge group.
-#
-# Branch protection requires one approving review (from any user with write
-# access) and restricts the merge button to the users listed below. Code
-# owners are auto-tagged for review when a PR opens, but the approving
-# review may come from any qualified reviewer.
-
-* @afrind @akash-a-n @gmarzot @michalhosna @mondain @Oxyd @peterchave @suhasHere @TimEvens


### PR DESCRIPTION
## What

Delete `CODEOWNERS` and remove the now-dangling reference to it from `.github/CONTRIBUTING.md`.

## Why

Branch protection on `main` has **`require_code_owner_reviews: false`**, so `CODEOWNERS` never gated merges. Its only live effect was auto-requesting review from all **nine** listed owners on every PR — review noise with no compensating enforcement.

Nothing about how merges actually work changes:

- The required **single approving review** can still come from any collaborator with write access.
- The **merge button** stays independently restricted via branch-protection `restrictions` (`suhasHere`, `afrind`, `gmarzot`, + the sync bot app); admins can still `--admin` override.
- No workflow or tooling reads `CODEOWNERS` (the auto-merge workflow gates on an existing approval + green checks, not code owners).

Reviewers can still be assigned per-PR as needed; this just drops the noisy auto-assignment default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/264)
<!-- Reviewable:end -->
