### PR TITLE
test: mock fetch() on MockMoQSession

### DIFF
--- a/moxygen/test/MockMoQSession.h
+++ b/moxygen/test/MockMoQSession.h
@@ -63,6 +63,12 @@ class MockMoQSession : public MoQSession {
       (override));
 
   MOCK_METHOD(
+      folly::coro::Task<Publisher::FetchResult>,
+      fetch,
+      (Fetch, std::shared_ptr<FetchConsumer>),
+      (override));
+
+  MOCK_METHOD(
       std::optional<uint64_t>,
       getNegotiatedVersion,
       (),


### PR DESCRIPTION
Lets relay tests assert the fetch a relay forwards upstream (e.g. a joining fetch resolved to a standalone range).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/291)
<!-- Reviewable:end -->
