### PR TITLE
relay: defer MoQForwarder onEmpty until iteration unwinds

### DIFF
--- a/moxygen/relay/MoQForwarder.cpp
+++ b/moxygen/relay/MoQForwarder.cpp
@@ -443,6 +443,10 @@ void MoQForwarder::removeSubscriber(
 void MoQForwarder::checkAndFireOnEmpty() {
   if (subscribers_.size() == passiveCount_) {
     if (subgroups_.empty()) {
+      if (deferOnEmptyDepth_ > 0) {
+        onEmptyPending_ = true;
+        return;
+      }
       if (callback_) {
         callback_->onEmpty(this);
       }
@@ -589,6 +593,7 @@ MoQForwarder::beginSubgroup(
     uint64_t subgroupID,
     Priority priority,
     BeginSubgroupOptions options) {
+  OnEmptyGuard guard(this);
   updateLargest(groupID, 0);
   SubgroupIdentifier subgroupIdentifier({groupID, subgroupID});
 
@@ -666,6 +671,7 @@ folly::Expected<folly::Unit, MoQPublishError> MoQForwarder::objectStream(
     const ObjectHeader& header,
     Payload payload,
     bool lastInGroup) {
+  OnEmptyGuard guard(this);
   updateLargest(header.group, header.id);
   countReceivedObject(header.group);
   return forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
@@ -683,6 +689,7 @@ folly::Expected<folly::Unit, MoQPublishError> MoQForwarder::datagram(
     const ObjectHeader& header,
     Payload payload,
     bool lastInGroup) {
+  OnEmptyGuard guard(this);
   updateLargest(header.group, header.id);
   countReceivedObject(header.group);
   return forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
@@ -699,6 +706,7 @@ folly::Expected<folly::Unit, MoQPublishError> MoQForwarder::datagram(
 folly::Expected<folly::Unit, MoQPublishError> MoQForwarder::publishDone(
     PublishDone pubDone) {
   XLOG(DBG1) << __func__ << " pubDone reason=" << pubDone.reasonPhrase;
+  OnEmptyGuard guard(this);
   draining_ = true;
   if (callback_) {
     // Signal source termination before draining subscribers, so any owning
@@ -999,6 +1007,7 @@ MoQForwarder::SubgroupForwarder::object(
     Payload payload,
     Extensions extensions,
     bool finSubgroup) {
+  OnEmptyGuard guard(forwarder_);
   if (currentObjectLength_) {
     return folly::makeUnexpected(MoQPublishError(
         MoQPublishError::API_ERROR, "Still publishing previous object"));
@@ -1035,6 +1044,7 @@ MoQForwarder::SubgroupForwarder::beginObject(
     Payload initialPayload,
     Extensions extensions) {
   // TODO: use a shared class for object publish state validation
+  OnEmptyGuard guard(forwarder_);
   updateLargest(identifier_.group, objectID);
   if (currentObjectLength_) {
     return folly::makeUnexpected(MoQPublishError(
@@ -1064,6 +1074,7 @@ MoQForwarder::SubgroupForwarder::beginObject(
 
 folly::Expected<folly::Unit, MoQPublishError>
 MoQForwarder::SubgroupForwarder::endOfGroup(uint64_t endOfGroupObjectID) {
+  OnEmptyGuard guard(forwarder_);
   if (currentObjectLength_) {
     return folly::makeUnexpected(MoQPublishError(
         MoQPublishError::API_ERROR, "Still publishing previous object"));
@@ -1090,6 +1101,7 @@ MoQForwarder::SubgroupForwarder::endOfGroup(uint64_t endOfGroupObjectID) {
 folly::Expected<folly::Unit, MoQPublishError>
 MoQForwarder::SubgroupForwarder::endOfTrackAndGroup(
     uint64_t endOfTrackObjectID) {
+  OnEmptyGuard guard(forwarder_);
   if (currentObjectLength_) {
     return folly::makeUnexpected(MoQPublishError(
         MoQPublishError::API_ERROR, "Still publishing previous object"));
@@ -1119,6 +1131,7 @@ MoQForwarder::SubgroupForwarder::endOfTrackAndGroup(
 
 folly::Expected<folly::Unit, MoQPublishError>
 MoQForwarder::SubgroupForwarder::endOfSubgroup() {
+  OnEmptyGuard guard(forwarder_);
   if (currentObjectLength_) {
     return folly::makeUnexpected(MoQPublishError(
         MoQPublishError::API_ERROR, "Still publishing previous object"));
@@ -1139,6 +1152,7 @@ MoQForwarder::SubgroupForwarder::endOfSubgroup() {
 }
 
 void MoQForwarder::SubgroupForwarder::reset(ResetStreamErrorCode error) {
+  OnEmptyGuard guard(forwarder_);
   forEachSubscriberSubgroup(
       [&](const std::shared_ptr<Subscriber>& sub,
           const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
@@ -1152,6 +1166,7 @@ folly::Expected<ObjectPublishStatus, MoQPublishError>
 MoQForwarder::SubgroupForwarder::objectPayload(
     Payload payload,
     bool finSubgroup) {
+  OnEmptyGuard guard(forwarder_);
   if (!currentObjectLength_) {
     return folly::makeUnexpected(MoQPublishError(
         MoQPublishError::API_ERROR, "Haven't started publishing object"));

--- a/moxygen/relay/MoQForwarder.h
+++ b/moxygen/relay/MoQForwarder.h
@@ -403,6 +403,28 @@ class MoQForwarder : public TrackConsumer {
   // fires onEmpty callback if so
   void checkAndFireOnEmpty();
 
+  // onEmpty may destroy this forwarder, so a live OnEmptyGuard defers it until
+  // iteration unwinds; the outermost guard re-checks emptiness and fires once.
+  uint32_t deferOnEmptyDepth_{0};
+  bool onEmptyPending_{false};
+  struct OnEmptyGuard {
+    explicit OnEmptyGuard(MoQForwarder* forwarder) : forwarder_(forwarder) {
+      if (forwarder_) {
+        forwarder_->deferOnEmptyDepth_++;
+      }
+    }
+    ~OnEmptyGuard() {
+      if (forwarder_ && --forwarder_->deferOnEmptyDepth_ == 0 &&
+          forwarder_->onEmptyPending_) {
+        forwarder_->onEmptyPending_ = false;
+        forwarder_->checkAndFireOnEmpty();
+      }
+    }
+    OnEmptyGuard(const OnEmptyGuard&) = delete;
+    OnEmptyGuard& operator=(const OnEmptyGuard&) = delete;
+    MoQForwarder* forwarder_;
+  };
+
   // Helper that removes a subscriber given an iterator (avoids lookup)
   void removeSubscriberIt(
       folly::F14FastMap<const void*, std::shared_ptr<Subscriber>>::iterator

--- a/moxygen/relay/test/MoQForwarderTest.cpp
+++ b/moxygen/relay/test/MoQForwarderTest.cpp
@@ -1220,4 +1220,43 @@ TEST_F(MoQForwarderTest, SubscriberDetachedOnForwarderDestruction) {
   subscriber->onPublishOk(pubOk);
 }
 
+// Test: removing the last non-passive subscriber mid-iteration fires onEmpty
+// (passive subscribers still occupy the map), which can destroy the forwarder.
+// forEachSubscriber must not touch the forwarder after that. Repro for the
+// passive-tail use-after-free: the non-passive subscriber is removed during the
+// loop and a passive entry remains to be iterated over a freed forwarder.
+TEST_F(MoQForwarderTest, RemoveLastNonPassiveDuringIterationWithPassiveTail) {
+  auto session = createMockSession();
+
+  auto forwarder = std::make_shared<MoQForwarder>(kFwdTestTrackName);
+  auto callback = std::make_shared<ForwarderDestroyingCallback>(forwarder);
+  forwarder->setCallback(callback);
+
+  // Non-passive subscriber whose objectStream returns a hard error, so it is
+  // removed during forEachSubscriber.
+  auto nonPassiveConsumer = createMockConsumer();
+  EXPECT_CALL(*nonPassiveConsumer, objectStream(_, _, _))
+      .WillOnce(Return(folly::makeUnexpected(
+          MoQPublishError(MoQPublishError::WRITE_ERROR, "transport broken"))));
+  forwarder->addSubscriber(
+      session, /*forward=*/true, nonPassiveConsumer, /*passive=*/false);
+
+  // Passive subscriber that remains in the map after the non-passive is gone.
+  auto passiveConsumer = createMockConsumer();
+  ON_CALL(*passiveConsumer, objectStream(_, _, _))
+      .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+  forwarder->addChannelSubscriber(
+      reinterpret_cast<folly::Executor*>(this),
+      /*forward=*/true,
+      passiveConsumer,
+      /*passive=*/true);
+
+  // Fan out an object. The non-passive subscriber errors and is removed; with
+  // only the passive subscriber left, onEmpty fires and destroys the forwarder.
+  // Before the fix, forEachSubscriber then dereferences the freed forwarder.
+  forwarder->objectStream(ObjectHeader(0, 0, 0, 0, 10), test::makeBuf(10));
+
+  EXPECT_EQ(forwarder, nullptr);
+}
+
 } // namespace moxygen::test


### PR DESCRIPTION
Removing the last non-passive subscriber mid-iteration fired onEmpty while passive subscribers still occupied subscribers_, letting the callback destroy the forwarder underneath forEachSubscriber. Hold an OnEmptyGuard for each public operation; checkAndFireOnEmpty records the request while a guard is live and the outermost guard re-checks emptiness and fires once iteration is done.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/295)
<!-- Reviewable:end -->
