### PR TITLE
relay: reset open subgroup consumers on SubgroupForwarder detach

### DIFF
--- a/moxygen/relay/MoQForwarder.cpp
+++ b/moxygen/relay/MoQForwarder.cpp
@@ -940,6 +940,17 @@ MoQForwarder::SubgroupForwarder::SubgroupForwarder(
       options_(options) {}
 
 void MoQForwarder::SubgroupForwarder::detach() {
+  // Reset still-open subgroup consumers while subscribers are reachable: once
+  // forwarder_ is null, forEachSubscriberSubgroup bails and a later reset() is
+  // lost, leaving the consumer without its required terminal.
+  if (forwarder_) {
+    forwarder_->forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
+      auto it = sub->subgroups.find(identifier_);
+      if (it != sub->subgroups.end() && it->second) {
+        it->second->reset(ResetStreamErrorCode::SESSION_CLOSED);
+      }
+    });
+  }
   forwarder_ = nullptr;
 }
 

--- a/moxygen/relay/test/MoQForwarderTest.cpp
+++ b/moxygen/relay/test/MoQForwarderTest.cpp
@@ -1220,6 +1220,48 @@ TEST_F(MoQForwarderTest, SubscriberDetachedOnForwarderDestruction) {
   subscriber->onPublishOk(pubOk);
 }
 
+// Test: destroying the forwarder while a subgroup is still open resets the
+// downstream subgroup consumer. The SubgroupForwarder must reset open consumers
+// during detach(), while subscribers are still reachable: once forwarder_ is
+// null, forEachSubscriberSubgroup bails and any later reset() is lost, leaving
+// the consumer without its required terminal.
+TEST_F(MoQForwarderTest, SubgroupConsumersResetOnForwarderDestruction) {
+  auto session = createMockSession();
+  auto consumer = createMockConsumer();
+
+  std::shared_ptr<MockSubgroupConsumer> sg;
+  EXPECT_CALL(*consumer, beginSubgroup(0, 0, _, _))
+      .WillOnce([this, &sg](
+                    uint64_t,
+                    uint64_t,
+                    uint8_t,
+                    moxygen::TrackConsumer::BeginSubgroupOptions) {
+        sg = createMockSubgroupConsumer();
+        return folly::
+            makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg);
+      });
+
+  auto forwarder = std::make_shared<MoQForwarder>(kFwdTestTrackName);
+  auto subscriber = addSubscriber(*forwarder, session, consumer, RequestID(1));
+  ASSERT_NE(subscriber, nullptr);
+
+  // Open a subgroup, leaving the downstream consumer attached to the
+  // subscriber. The publisher keeps its handle to the SubgroupForwarder.
+  auto sgRes = forwarder->beginSubgroup(0, 0, 0);
+  ASSERT_TRUE(sgRes.hasValue());
+  auto pubSg = *sgRes;
+  ASSERT_NE(sg, nullptr);
+
+  // Destroying the forwarder detaches the open subgroup; the still-attached
+  // downstream consumer must be reset so its stream is properly terminated.
+  EXPECT_CALL(*sg, reset(ResetStreamErrorCode::SESSION_CLOSED));
+  forwarder.reset();
+
+  // Resetting the publisher's now-detached handle is a safe no-op (the consumer
+  // was already reset during detach, so no second reset is delivered).
+  pubSg->reset(ResetStreamErrorCode::SESSION_CLOSED);
+}
+
 // Test: removing the last non-passive subscriber mid-iteration fires onEmpty
 // (passive subscribers still occupy the map), which can destroy the forwarder.
 // forEachSubscriber must not touch the forwarder after that. Repro for the


### PR DESCRIPTION
When a SubgroupForwarder is detached (e.g. the MoQForwarder is destroyed while a subgroup is still open), detach() only nulled forwarder_. Any later reset() on the publisher's still-held handle then bailed out of forEachSubscriberSubgroup, so the downstream subgroup consumer never received its terminal and its stream was left dangling.

Reset still-open consumers in detach() while subscribers are still reachable, before clearing forwarder_.

Add a regression test that opens a subgroup, destroys the forwarder, and asserts the downstream consumer is reset with SESSION_CLOSED.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/298)
<!-- Reviewable:end -->
