### PR TITLE
Reset open subgroups when a subscription is cancelled

### DIFF
--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -2282,6 +2282,10 @@ void MoQSession::cleanup() {
     sub->subscribeError({/*TrackReceiveState fills in subId*/ 0,
                          SubscribeErrorCode::INTERNAL_ERROR,
                          "session closed"});
+    // Wake read loops parked in readStreamData on an open subgroup: the
+    // transport may cancel the read handle without enqueuing an error, which
+    // the state-token await misses, leaking the open subgroup consumers.
+    sub->cancel();
   }
   subTracks_.clear();
   // We parse a publishDone after cleanup
@@ -3482,7 +3486,9 @@ class ObjectStreamCallback : public MoQObjectStreamCodec::ObjectCallback {
     if (fetchState_) {
       return !fetchState_->getFetchCallback();
     } else if (subscribeState_) {
-      return !subgroupCallback_ || subscribeState_->isCancelled();
+      // A cancelled subscription still owes its open subgroup consumer one
+      // terminal (reset) per the MoQConsumers contract; only skip when null.
+      return !subgroupCallback_;
     }
     return true;
   }

--- a/moxygen/test/MoQSessionObjectDeliveryTests.cpp
+++ b/moxygen/test/MoQSessionObjectDeliveryTests.cpp
@@ -1057,6 +1057,56 @@ CO_TEST_P_X(MoQSessionTest, ObjectCallbackErrorResetsSubgroupConsumer) {
   clientSession_->close(SessionCloseErrorCode::NO_ERROR);
 }
 
+// Cleanup must reset an open subgroup. The session is closed with a subgroup
+// still open; cleanup() cancels the subscribe state, and isCancelled() must not
+// then suppress reset() on the open subgroup consumer. Reverting the
+// isCancelled() change hangs this test on resetBaton.
+//
+// Note: FakeSharedWebTransport's close also resets the peer's streams, so the
+// read loop here can wake via that error too; this exercises the cleanup/reset
+// contract but does not isolate the rh-token-cancel-without-error wake.
+CO_TEST_P_X(MoQSessionTest, OpenSubgroupResetDuringSessionCleanup) {
+  co_await setupMoQSession();
+
+  expectSubscribe([this](auto sub, auto pub) -> TaskSubscribeResult {
+    eventBase_.add([pub, sub] {
+      auto sgp = pub->beginSubgroup(0, 0, 0).value();
+      // Leave the subgroup OPEN: no endOfSubgroup, no publishDone.
+      sgp->object(0, moxygen::test::makeBuf(10));
+    });
+    co_return makeSubscribeOkResult(sub, AbsoluteLocation{0, 0});
+  });
+
+  auto sg1 = std::make_shared<testing::StrictMock<MockSubgroupConsumer>>();
+  folly::coro::Baton objectReceived;
+  folly::coro::Baton resetBaton;
+
+  EXPECT_CALL(*subscribeCallback_, beginSubgroup(0, 0, 0, _))
+      .WillOnce(testing::Return(sg1));
+  EXPECT_CALL(*sg1, object(0, _, _, false)).WillOnce([&](auto...) {
+    objectReceived.post();
+    return folly::unit;
+  });
+  // cleanup() delivers PUBLISH_DONE before cancelling the loop.
+  EXPECT_CALL(*subscribeCallback_, publishDone(_))
+      .WillOnce(testing::Return(folly::unit));
+  EXPECT_CALL(*sg1, reset(_)).WillOnce([&](auto) {
+    resetBaton.post();
+    return folly::unit;
+  });
+
+  auto res = co_await clientSession_->subscribe(
+      getSubscribe(kTestTrackName), subscribeCallback_);
+  EXPECT_FALSE(res.hasError());
+
+  // Subgroup is open and the read loop is parked on readStreamData().
+  co_await objectReceived;
+
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+
+  co_await resetBaton;
+}
+
 namespace {
 class NullLogger : public MLogger {
  public:

--- a/moxygen/test/MoQSessionSubscribeTests.cpp
+++ b/moxygen/test/MoQSessionSubscribeTests.cpp
@@ -487,6 +487,9 @@ CO_TEST_P_X(MoQSessionTest, Unsubscribe) {
       }));
   EXPECT_CALL(*sg, object(_, _, _, _))
       .WillRepeatedly(testing::Return(folly::unit));
+  // Unsubscribe cancels the subscription; its still-open subgroup is owed a
+  // terminal reset().
+  EXPECT_CALL(*sg, reset(_));
   auto res =
       co_await clientSession_->subscribe(subscribeRequest, subscribeCallback_);
   co_await subgroupCreated;

--- a/moxygen/test/MoQSessionTests.cpp
+++ b/moxygen/test/MoQSessionTests.cpp
@@ -868,6 +868,8 @@ CO_TEST_P_X(MoQUniControlTest, UniControlDataStreamBeforeSetup) {
         baton.post();
         return folly::unit;
       });
+  // unsubscribe() cancels the subscription; its open subgroup is reset.
+  EXPECT_CALL(*sgConsumer, reset(_));
 
   auto subscribeRequest = getSubscribe(kTestTrackName);
   auto res =


### PR DESCRIPTION
When a subscription's read loop is parked in readStreamData on an open subgroup, session cleanup could leak the open subgroup consumer: the transport may cancel the read handle without enqueuing an error, which the state-token await misses. cleanup() now cancels the subscribe state to wake the parked loop, and ObjectStreamCallback::isCancelled() no longer treats a cancelled subscription as terminal for an open subgroup, so the consumer still receives its owed reset() per the MoQConsumers contract.

This also applies to app-initiated unsubscribe(), which shares the same cancel() path: an open subgroup is now reset() on unsubscribe. Updated the Unsubscribe and UniControlDataStreamBeforeSetup tests to expect it, and added OpenSubgroupResetDuringSessionCleanup covering the cleanup case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/299)
<!-- Reviewable:end -->
