### PR TITLE
moqperf: export end-to-end latency as a Prometheus textfile

### DIFF
--- a/moxygen/moqtest/LatencyHistogram.h
+++ b/moxygen/moqtest/LatencyHistogram.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace moxygen {
+
+// Fixed exponential latency bucket upper bounds, in milliseconds (inclusive).
+// Chosen to resolve the single-digit-ms range where end-to-end latency normally
+// lives while still capturing multi-second tails.
+inline constexpr std::array<uint64_t, 13> kLatencyBucketsMs = {
+    1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096};
+
+// Plain (non-atomic) value type holding a fixed-boundary latency histogram,
+// shaped for Prometheus export. Used to accumulate/merge snapshots and format
+// output on a single thread. Live cross-thread accumulation lives in the client
+// as atomics; snapshotLatencyHist() converts those into one of these.
+//
+// buckets_[i] counts observations in bucket i; buckets_[kNumBounds] is the +Inf
+// overflow bucket (values above the last explicit bound).
+class LatencyHistogram {
+ public:
+  static constexpr size_t kNumBounds = kLatencyBucketsMs.size();
+  static constexpr size_t kNumBuckets = kNumBounds + 1;
+
+  // Bucket a value falls into (kNumBounds == +Inf overflow). Single source of
+  // truth so the atomic accumulator and addValue() agree.
+  static size_t bucketIndex(uint64_t latencyMs) {
+    for (size_t i = 0; i < kNumBounds; ++i) {
+      if (latencyMs <= kLatencyBucketsMs[i]) {
+        return i;
+      }
+    }
+    return kNumBounds;
+  }
+
+  void addValue(uint64_t latencyMs) {
+    ++count_;
+    sum_ += latencyMs;
+    ++buckets_[bucketIndex(latencyMs)];
+  }
+
+  void merge(const LatencyHistogram& other) {
+    count_ += other.count_;
+    sum_ += other.sum_;
+    for (size_t i = 0; i < kNumBuckets; ++i) {
+      buckets_[i] += other.buckets_[i];
+    }
+  }
+
+  void addRawBucket(size_t i, uint64_t n) {
+    buckets_[i] += n;
+  }
+  void addSum(uint64_t s) {
+    sum_ += s;
+  }
+  void addCount(uint64_t c) {
+    count_ += c;
+  }
+
+  // out[i] = cumulative count of observations <= kLatencyBucketsMs[i].
+  // out[kNumBounds] = total count (the +Inf bucket).
+  std::array<uint64_t, kNumBuckets> cumulative() const {
+    std::array<uint64_t, kNumBuckets> out{};
+    uint64_t running = 0;
+    for (size_t i = 0; i < kNumBounds; ++i) {
+      running += buckets_[i];
+      out[i] = running;
+    }
+    out[kNumBounds] = count_;
+    return out;
+  }
+
+  uint64_t sum() const {
+    return sum_;
+  }
+  uint64_t count() const {
+    return count_;
+  }
+
+ private:
+  std::array<uint64_t, kNumBuckets> buckets_{};
+  uint64_t sum_{0};
+  uint64_t count_{0};
+};
+
+} // namespace moxygen

--- a/moxygen/moqtest/MoQPerfTestClient.cpp
+++ b/moxygen/moqtest/MoQPerfTestClient.cpp
@@ -492,6 +492,11 @@ std::optional<AbsoluteLocation> MoQPerfTestClient::getLargestObjectSeen()
 }
 
 void MoQPerfTestClient::recordLatency(uint64_t latencyMs) {
+  latencyBuckets_[LatencyHistogram::bucketIndex(latencyMs)].fetch_add(
+      1, std::memory_order_relaxed);
+  latencyHistSum_.fetch_add(latencyMs, std::memory_order_relaxed);
+  latencyHistCount_.fetch_add(1, std::memory_order_relaxed);
+
   intervalLatencySum_.fetch_add(latencyMs, std::memory_order_relaxed);
   intervalLatencyCount_.fetch_add(1, std::memory_order_relaxed);
 
@@ -544,6 +549,16 @@ MoQPerfTestClient::TestResults MoQPerfTestClient::getResults() const {
   results.durationSeconds = elapsed;
 
   return results;
+}
+
+LatencyHistogram MoQPerfTestClient::snapshotLatencyHist() const {
+  LatencyHistogram hist;
+  for (size_t i = 0; i < latencyBuckets_.size(); ++i) {
+    hist.addRawBucket(i, latencyBuckets_[i].load(std::memory_order_relaxed));
+  }
+  hist.addSum(latencyHistSum_.load(std::memory_order_relaxed));
+  hist.addCount(latencyHistCount_.load(std::memory_order_relaxed));
+  return hist;
 }
 
 } // namespace moxygen

--- a/moxygen/moqtest/MoQPerfTestClient.h
+++ b/moxygen/moqtest/MoQPerfTestClient.h
@@ -16,6 +16,7 @@
 #include "moxygen/MoQClientBase.h"
 #include "moxygen/ObjectReceiver.h"
 #include "moxygen/events/MoQFollyExecutorImpl.h"
+#include "moxygen/moqtest/LatencyHistogram.h"
 #include "moxygen/moqtest/Types.h"
 #include "moxygen/samples/util/Utils.h"
 
@@ -131,6 +132,9 @@ class MoQPerfTestClient {
 
   TestResults getResults() const;
 
+  // Safe to call from any thread: reads the atomic bucket counters.
+  LatencyHistogram snapshotLatencyHist() const;
+
   void completed();
   void recordReset();
   void recordFailure();
@@ -183,6 +187,12 @@ class MoQPerfTestClient {
   mutable std::atomic<uint64_t> intervalLatencyMin_{
       std::numeric_limits<uint64_t>::max()};
   mutable std::atomic<uint64_t> intervalLatencyMax_{0};
+  // Cumulative latency histogram (whole run). Atomic so snapshotLatencyHist()
+  // can read it from the aggregation thread without hopping onto evb_.
+  std::array<std::atomic<uint64_t>, LatencyHistogram::kNumBuckets>
+      latencyBuckets_{};
+  std::atomic<uint64_t> latencyHistSum_{0};
+  std::atomic<uint64_t> latencyHistCount_{0};
 };
 
 } // namespace moxygen

--- a/moxygen/moqtest/MoQPerfTestClientMain.cpp
+++ b/moxygen/moqtest/MoQPerfTestClientMain.cpp
@@ -7,9 +7,11 @@
 #include <atomic>
 #include <iomanip>
 #include <memory>
+#include <sstream>
 #include <thread>
 #include <vector>
 
+#include <folly/FileUtil.h>
 #include <folly/coro/BlockingWait.h>
 #include <folly/coro/Sleep.h>
 #include <folly/executors/IOThreadPoolExecutor.h>
@@ -51,6 +53,12 @@ DEFINE_uint32(
     "Size of other objects in group (P-frame)");
 DEFINE_uint32(delivery_timeout, 500, "Delivery timeout in milliseconds");
 DEFINE_uint32(objects_per_group, 30, "Number of objects per group");
+DEFINE_string(
+    metrics_out,
+    "",
+    "If set, write Prometheus .prom metrics (including the end-to-end latency "
+    "histogram) to this path once per second, for a node_exporter textfile "
+    "collector to scrape");
 
 // Shared stats structure for cross-thread aggregation
 struct SharedStats {
@@ -61,11 +69,107 @@ struct SharedStats {
   std::atomic<bool> trackEnded{false};
 };
 
+namespace {
+
+struct PerfPromSnapshot {
+  uint32_t subscribers{0};
+  double throughputMbps{0.0};
+  uint64_t totalObjects{0};
+  uint64_t totalBytes{0};
+  uint32_t totalResets{0};
+  uint32_t totalFailures{0};
+  double avgLatencyMs{0.0};
+  moxygen::LatencyHistogram latency;
+};
+
+std::string escapeLabelValue(const std::string& v) {
+  std::string out;
+  out.reserve(v.size());
+  for (char c : v) {
+    if (c == '\\' || c == '"') {
+      out.push_back('\\');
+    }
+    out.push_back(c);
+  }
+  return out;
+}
+
+// Rewrite the whole .prom file each tick. Buckets are cumulative over the run,
+// so Prometheus rate()/histogram_quantile() work across scrapes. writeFileAtomic
+// does the temp-write + rename the textfile collector requires.
+void writePromFile(
+    const std::string& path,
+    const std::string& labels,
+    const PerfPromSnapshot& s) {
+  std::ostringstream os;
+  auto gauge = [&](const char* name, const char* help, double value) {
+    os << "# HELP " << name << " " << help << "\n"
+       << "# TYPE " << name << " gauge\n"
+       << name << "{" << labels << "} " << value << "\n";
+  };
+  auto counter = [&](const char* name, const char* help, uint64_t value) {
+    os << "# HELP " << name << " " << help << "\n"
+       << "# TYPE " << name << " counter\n"
+       << name << "{" << labels << "} " << value << "\n";
+  };
+
+  gauge("moqperf_subscribers", "Active subscribers", s.subscribers);
+  gauge(
+      "moqperf_throughput_mbps",
+      "Interval throughput in Mbps",
+      s.throughputMbps);
+  counter("moqperf_objects_total", "Objects received", s.totalObjects);
+  counter("moqperf_bytes_total", "Bytes received", s.totalBytes);
+  counter("moqperf_resets_total", "Subgroup resets", s.totalResets);
+  counter("moqperf_failures_total", "Subscribe failures", s.totalFailures);
+  gauge(
+      "moqperf_latency_avg_ms",
+      "Run-average end-to-end object latency in ms",
+      s.avgLatencyMs);
+
+  const char* h = "moqperf_object_latency_seconds";
+  os << "# HELP " << h << " End-to-end object latency in seconds\n"
+     << "# TYPE " << h << " histogram\n";
+  auto cum = s.latency.cumulative();
+  for (size_t i = 0; i < moxygen::LatencyHistogram::kNumBounds; ++i) {
+    double leSec = static_cast<double>(moxygen::kLatencyBucketsMs[i]) / 1000.0;
+    os << h << "_bucket{" << labels << ",le=\"" << leSec << "\"} " << cum[i]
+       << "\n";
+  }
+  os << h << "_bucket{" << labels << ",le=\"+Inf\"} "
+     << cum[moxygen::LatencyHistogram::kNumBounds] << "\n";
+  os << h << "_sum{" << labels << "} "
+     << (static_cast<double>(s.latency.sum()) / 1000.0) << "\n";
+  os << h << "_count{" << labels << "} " << s.latency.count() << "\n";
+
+  auto data = os.str();
+  try {
+    folly::writeFileAtomic(path, folly::StringPiece(data));
+  } catch (const std::exception& ex) {
+    XLOG(ERR) << "Failed to write metrics file " << path << ": " << ex.what();
+  }
+}
+
+// Sum every client's cumulative latency histogram. Safe from any thread:
+// snapshotLatencyHist() reads atomic counters, no EventBase hop.
+moxygen::LatencyHistogram mergeLatency(
+    const std::vector<std::unique_ptr<moxygen::MoQPerfTestClient>>& clients) {
+  moxygen::LatencyHistogram hist;
+  for (const auto& client : clients) {
+    hist.merge(client->snapshotLatencyHist());
+  }
+  return hist;
+}
+
+} // namespace
+
 // Stats aggregation coroutine
 folly::coro::Task<void> aggregateStats(
     const std::vector<std::unique_ptr<moxygen::MoQPerfTestClient>>& clients,
     std::shared_ptr<SharedStats> sharedStats,
-    folly::CancellationToken cancelToken) {
+    folly::CancellationToken cancelToken,
+    std::string metricsOut,
+    std::string promLabels) {
   auto startTime = std::chrono::steady_clock::now();
   uint64_t lastTotalObjects = 0;
   uint64_t lastTotalBytes = 0;
@@ -157,6 +261,19 @@ folly::coro::Task<void> aggregateStats(
                << " total"
                << " | Done: " << totalCompleted << "/" << clients.size();
 
+    if (!metricsOut.empty()) {
+      PerfPromSnapshot snap;
+      snap.subscribers = currentSubscribers;
+      snap.throughputMbps = mbps;
+      snap.totalObjects = totalObjects;
+      snap.totalBytes = totalBytes;
+      snap.totalResets = totalResets;
+      snap.totalFailures = totalFailures;
+      snap.avgLatencyMs = runAvgLatencyMs;
+      snap.latency = mergeLatency(clients);
+      writePromFile(metricsOut, promLabels, snap);
+    }
+
     // Check if all threads have completed
     if (totalCompleted >= clients.size()) {
       XLOG(INFO) << "[AGGREGATE] All tracks ended - stopping stats aggregation";
@@ -207,6 +324,15 @@ int main(int argc, char** argv) {
              << "/sec; Max subscribers (per thread): "
              << subscriberMaxPerThread;
 
+  std::string versionsLabel = FLAGS_versions.empty() ? "all" : FLAGS_versions;
+  std::ostringstream labelStream;
+  labelStream << "transport=\"" << escapeLabelValue(transportName) << "\""
+              << ",subs=\"" << FLAGS_subscriber_max << "\""
+              << ",first_object_size=\"" << FLAGS_first_object_size << "\""
+              << ",other_object_size=\"" << FLAGS_other_object_size << "\""
+              << ",versions=\"" << escapeLabelValue(versionsLabel) << "\"";
+  std::string promLabels = labelStream.str();
+
   try {
     auto url = proxygen::URL(FLAGS_relay_url);
     auto sharedStats = std::make_shared<SharedStats>();
@@ -246,7 +372,12 @@ int main(int argc, char** argv) {
     folly::ScopedEventBaseThread statsThread;
     folly::coro::co_withExecutor(
         statsThread.getEventBase(),
-        aggregateStats(clients, sharedStats, cancelSource.getToken()))
+        aggregateStats(
+            clients,
+            sharedStats,
+            cancelSource.getToken(),
+            FLAGS_metrics_out,
+            promLabels))
         .start();
 
     // Wait for all client tasks to complete
@@ -281,17 +412,32 @@ int main(int argc, char** argv) {
     auto duration = clients[0]->getResults().durationSeconds;
     XLOG(INFO) << "  Duration: " << duration << " seconds";
 
+    double throughputMbps = 0.0;
     if (totalBytes > 0 && duration > 0) {
       double mbytes = static_cast<double>(totalBytes) / (1024.0 * 1024.0);
-      double throughputMbps = (mbytes * 8.0) / static_cast<double>(duration);
+      throughputMbps = (mbytes * 8.0) / static_cast<double>(duration);
       XLOG(INFO) << "  Throughput: " << throughputMbps << " Mbps";
     }
 
+    double avgLatencyMs = 0.0;
     if (latencyObjects > 0) {
-      double avgLatencyMs = static_cast<double>(totalLatencyMs) /
+      avgLatencyMs = static_cast<double>(totalLatencyMs) /
           static_cast<double>(latencyObjects);
       XLOG(INFO) << "  Avg Object Latency: " << avgLatencyMs << " ms ("
                  << latencyObjects << " objects measured)";
+    }
+
+    // Client threads are already joined (executor->stop()), so the histograms
+    // are quiescent here; write one last snapshot to capture the final tail.
+    if (!FLAGS_metrics_out.empty()) {
+      PerfPromSnapshot snap;
+      snap.throughputMbps = throughputMbps;
+      snap.totalObjects = sharedStats->totalObjects.load();
+      snap.totalBytes = totalBytes;
+      snap.totalResets = sharedStats->totalResets.load();
+      snap.avgLatencyMs = avgLatencyMs;
+      snap.latency = mergeLatency(clients);
+      writePromFile(FLAGS_metrics_out, promLabels, snap);
     }
 
     if (sharedStats->trackEnded.load()) {


### PR DESCRIPTION
Add --metrics_out to moqperf_test_client. When set, the client writes a Prometheus text-exposition (.prom) file once per second for a node_exporter textfile collector to scrape, exposing the end-to-end object latency distribution plus throughput/objects/bytes/reset/failure counters.

- LatencyHistogram: fixed exponential-bucket latency histogram (1ms..4s) shaped for Prometheus cumulative le-bucket export.
- MoQPerfTestClient accumulates per-object latency into atomic bucket counters on its own EventBase; snapshotLatencyHist() reads them lock-free from the stats thread, so the hot path never blocks.
- Main merges the per-client histograms and writes the file via folly::writeFileAtomic (temp + rename), as the textfile collector requires.

Buckets are cumulative over the run so histogram_quantile()/rate() work across scrapes; the file is rewritten each second to stay fresh.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/307)
<!-- Reviewable:end -->
