### PR TITLE
build: distro-derivative support, ubuntu-24.04 artifacts, CONFIG-mode gtest probe

### DIFF
--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -140,6 +140,12 @@ jobs:
             debug_artifact: moxygen-ubuntu-22.04-amd64-dbg.tar.gz
             container: ""
 
+          - name: ubuntu-24.04-amd64
+            runner: ubuntu-24.04
+            artifact: moxygen-ubuntu-24.04-amd64.tar.gz
+            debug_artifact: moxygen-ubuntu-24.04-amd64-dbg.tar.gz
+            container: ""
+
           - name: macos-15-arm64
             runner: macos-15
             artifact: moxygen-macos-15-arm64.tar.gz

--- a/.github/workflows/omoq-dev-build.yml
+++ b/.github/workflows/omoq-dev-build.yml
@@ -28,12 +28,13 @@ on:
         options:
           - macos-15-arm64
           - ubuntu-22.04-amd64
+          - ubuntu-24.04-amd64
         default: macos-15-arm64
 
 jobs:
   build:
     name: dev build (${{ inputs.target }})
-    runs-on: ${{ inputs.target == 'macos-15-arm64' && 'macos-15' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.target == 'macos-15-arm64' && 'macos-15' || inputs.target == 'ubuntu-24.04-amd64' && 'ubuntu-24.04' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -210,8 +210,11 @@ set(FETCHCONTENT_QUIET OFF)
 # googletest 1.12+ required for move-only WillOnce support
 # (Ubuntu 22.04 ships 1.11 which doesn't support this)
 if(BUILD_TESTS)
-    # Try to find system googletest first
-    find_package(GTest 1.12.1 QUIET)
+    # Try to find system googletest first. CONFIG mode only: consumers of the
+    # installed tree (e.g. moqx) do find_package(GTest REQUIRED CONFIG), so a
+    # module-mode-only system googletest (libs/headers without cmake package
+    # config) must not short-circuit the FetchContent bundling below.
+    find_package(GTest 1.12.1 QUIET CONFIG)
 
     if(GTest_FOUND)
         message(STATUS "Using system googletest ${GTest_VERSION}")

--- a/standalone/install-system-deps.sh
+++ b/standalone/install-system-deps.sh
@@ -100,9 +100,21 @@ elif [[ -f /etc/os-release ]]; then
             install_fedora
             ;;
         *)
-            echo "Unsupported Linux distribution: $ID"
-            echo "Please install dependencies manually (see README.md)"
-            exit 1
+            # Derivatives (Linux Mint, Pop!_OS, LMDE, Rocky, Alma, ...)
+            # report their own ID; dispatch on ID_LIKE instead.
+            case " ${ID_LIKE:-} " in
+                *" ubuntu "*|*" debian "*)
+                    install_ubuntu
+                    ;;
+                *" fedora "*|*" rhel "*|*" centos "*)
+                    install_fedora
+                    ;;
+                *)
+                    echo "Unsupported Linux distribution: $ID (ID_LIKE='${ID_LIKE:-}')"
+                    echo "Please install dependencies manually (see README.md)"
+                    exit 1
+                    ;;
+            esac
             ;;
     esac
 else


### PR DESCRIPTION
Companion to the moqx linux-build-update PR — makes native (non-Docker) builds work beyond exactly Ubuntu 22.04 / Debian 12 hosts.

## Changes

**standalone/install-system-deps.sh: dispatch on ID_LIKE for derivatives**
Linux Mint reports `ID=linuxmint` (Pop!_OS `pop`, Rocky `rocky`, ...) so the installer refused to run on any derivative even though the right package set is obvious from `ID_LIKE`. Unknown IDs now fall back to an ID_LIKE dispatch (ubuntu/debian to the apt path, fedora/rhel/centos to the dnf path) before giving up.

**omoq-ci-main.yml: add ubuntu-24.04-amd64 to the publish matrix**
The snapshot release only shipped ubuntu-22.04, bookworm, and macos-15 tarballs, so hosts on the current Ubuntu LTS (and its derivatives) always fell back to a 15-30 min source build. The release job downloads all artifacts generically, so the new tarball is picked up automatically.

**omoq-dev-build.yml: add ubuntu-24.04-amd64 target**
Parity with the publish matrix, so moqx's dev-artifact fallback also works for 24.04 pins.

**standalone/CMakeLists.txt: probe system googletest in CONFIG mode only**
Consumers of the installed tree (e.g. moqx) do `find_package(GTest REQUIRED CONFIG)`. The probe used module mode, so a googletest visible only to FindGTest.cmake (libs/headers without a cmake package config) short-circuited the FetchContent bundling and produced an install tree those consumers cannot configure against.

## Verification

On Linux Mint 22.3 (noble base, amd64): installer dispatch resolves to the apt path; full standalone from-source build completes; with the CONFIG probe the install tree ships `lib/cmake/GTest/GTestConfig.cmake` and moqx configures and builds against it. Workflow YAML validated with a parser; the ubuntu-24.04 matrix entry mirrors the 22.04 one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/309)
<!-- Reviewable:end -->
