### PR TITLE
logging: root every layer's XLOG category (standalone dep maps + picoquic bridge + smoke test)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ DeJitterTests
 # IDE / tooling
 .claude/
 .vscode/
+
+# Downstream test hook (the blanket *.cmake rule above would swallow it)
+!standalone/test/local.cmake

--- a/moxygen/openmoq/transport/pico/PicoQuicXLogSink.cpp
+++ b/moxygen/openmoq/transport/pico/PicoQuicXLogSink.cpp
@@ -20,6 +20,11 @@ extern "C" {
 #include "picoquic_unified_log.h"
 }
 
+// Route this TU's XLOG() calls to the "quic.picoquic" category operators target
+// (--logging=quic.picoquic=DBG3), overriding the __FILE__-derived default. Must
+// be at global scope, once per TU — the macro reopens namespace folly.
+XLOG_SET_CATEGORY_NAME("quic.picoquic")
+
 namespace moxygen::openmoq::pico {
 namespace {
 

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -471,6 +471,11 @@ if(NOT folly_POPULATED)
     FetchContent_Populate(folly)
     apply_dep_patches(folly "${folly_SOURCE_DIR}")
     set(CMAKE_INSTALL_DIR "lib/cmake/folly" CACHE STRING "" FORCE)
+    # Root this dep's XLOG categories at its natural name (folly.*, fizz.*, ...)
+    # instead of the absolute build path, by rewriting __FILE__ from the consumer
+    # side — we don't own these deps' CMakeLists. -fmacro-prefix-map, not
+    # -ffile-prefix-map: debug-info paths stay intact and the maps stack.
+    add_compile_options(-fmacro-prefix-map=${folly_SOURCE_DIR}/=)
     add_subdirectory(${folly_SOURCE_DIR} ${folly_BINARY_DIR} ${_EXCLUDE_FLAG})
 endif()
 
@@ -479,6 +484,8 @@ if(NOT fizz_POPULATED)
     FetchContent_Populate(fizz)
     apply_dep_patches(fizz "${fizz_SOURCE_DIR}")
     set(CMAKE_INSTALL_DIR "lib/cmake/fizz" CACHE STRING "" FORCE)
+    # Root fizz XLOG categories at fizz.* (see folly block above).
+    add_compile_options(-fmacro-prefix-map=${fizz_SOURCE_DIR}/=)
     add_subdirectory(${fizz_SOURCE_DIR}/fizz ${fizz_BINARY_DIR} ${_EXCLUDE_FLAG})
 endif()
 
@@ -487,6 +494,8 @@ if(NOT wangle_POPULATED)
     FetchContent_Populate(wangle)
     apply_dep_patches(wangle "${wangle_SOURCE_DIR}")
     set(CMAKE_INSTALL_DIR "lib/cmake/wangle" CACHE STRING "" FORCE)
+    # Root wangle XLOG categories at wangle.* (see folly block above).
+    add_compile_options(-fmacro-prefix-map=${wangle_SOURCE_DIR}/=)
     add_subdirectory(${wangle_SOURCE_DIR}/wangle ${wangle_BINARY_DIR} ${_EXCLUDE_FLAG})
 endif()
 
@@ -495,6 +504,9 @@ if(NOT mvfst_POPULATED)
     FetchContent_Populate(mvfst)
     apply_dep_patches(mvfst "${mvfst_SOURCE_DIR}")
     # mvfst uses CMAKE_INSTALL_MODULE_DIR, not CMAKE_INSTALL_DIR — no conflict
+    # mvfst's tree is rooted at quic/; map it to quic/mvfst/ so it lands on the
+    # documented quic.mvfst.* root rather than claiming a bare quic.*.
+    add_compile_options(-fmacro-prefix-map=${mvfst_SOURCE_DIR}/quic/=quic/mvfst/)
     add_subdirectory(${mvfst_SOURCE_DIR} ${mvfst_BINARY_DIR} ${_EXCLUDE_FLAG})
 endif()
 
@@ -503,6 +515,8 @@ if(NOT proxygen_POPULATED)
     FetchContent_Populate(proxygen)
     apply_dep_patches(proxygen "${proxygen_SOURCE_DIR}")
     set(CMAKE_INSTALL_DIR "lib/cmake/proxygen" CACHE STRING "" FORCE)
+    # Root proxygen XLOG categories at proxygen.* (see folly block above).
+    add_compile_options(-fmacro-prefix-map=${proxygen_SOURCE_DIR}/=)
     add_subdirectory(${proxygen_SOURCE_DIR} ${proxygen_BINARY_DIR} ${_EXCLUDE_FLAG})
 endif()
 
@@ -553,6 +567,14 @@ if(BUILD_TESTS)
 endif()
 
 # Include moxygen's main CMakeLists.txt
+# Root moxygen's own XLOG categories at moxygen.* here too: this build adds the
+# inner moxygen/ dir directly, so the repo-root CMakeLists.txt that sets
+# FOLLY_XLOG_STRIP_PREFIXES is never processed. Strip the repo root, not the
+# inner moxygen/ dir — sources are <repo>/moxygen/MoQSession.cpp, so the leading
+# moxygen/ component has to survive.
+get_filename_component(_MOXYGEN_REPO_ROOT
+  "${CMAKE_CURRENT_SOURCE_DIR}/.." ABSOLUTE)
+add_compile_options(-fmacro-prefix-map=${_MOXYGEN_REPO_ROOT}/=)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../moxygen moxygen)
 
 moxygen_install_headers(moxygen ${CMAKE_CURRENT_SOURCE_DIR}/../moxygen)

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -579,6 +579,13 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../moxygen moxygen)
 
 moxygen_install_headers(moxygen ${CMAKE_CURRENT_SOURCE_DIR}/../moxygen)
 
+# XLOG category regression test; drives the sample binaries, so register it only
+# when they are built.
+if(BUILD_TESTS AND TARGET moqdateserver AND TARGET moqtextclient)
+  enable_testing()
+  add_subdirectory(test)
+endif()
+
 # =============================================================================
 # Installation (mirrors main CMakeLists.txt)
 # =============================================================================

--- a/standalone/test/CMakeLists.txt
+++ b/standalone/test/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Regression guard for the per-layer XLOG category rooting in ../CMakeLists.txt:
+# drives a short mvfst session and asserts each layer's --logging selector scopes
+# to that layer.
+add_test(
+  NAME xlog_category_roots
+  COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/xlog_category_smoke.sh
+          $<TARGET_FILE:moqdateserver> $<TARGET_FILE:moqtextclient>
+)
+set_tests_properties(xlog_category_roots PROPERTIES
+  LABELS "logging;smoke" TIMEOUT 180)
+
+# Extension point for tests that exist only in a downstream tree.
+include(${CMAKE_CURRENT_SOURCE_DIR}/local.cmake OPTIONAL)

--- a/standalone/test/local.cmake
+++ b/standalone/test/local.cmake
@@ -1,0 +1,11 @@
+# Tests for transports that exist only in this tree. The pico sample binaries
+# are built under BUILD_PICOQUIC.
+if(TARGET pico_evb_relay_server AND TARGET pico_evb_text_client)
+  add_test(
+    NAME xlog_category_pico
+    COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/xlog_category_pico_smoke.sh
+            $<TARGET_FILE:pico_evb_relay_server> $<TARGET_FILE:pico_evb_text_client>
+  )
+  set_tests_properties(xlog_category_pico PROPERTIES
+    LABELS "logging;smoke" TIMEOUT 180)
+endif()

--- a/standalone/test/xlog_category_pico_smoke.sh
+++ b/standalone/test/xlog_category_pico_smoke.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# xlog_category_pico_smoke.sh — prove the picoquic bridge logs under the
+# "quic.picoquic" category set by XLOG_SET_CATEGORY_NAME in PicoQuicXLogSink.
+#
+# The proof is the exclusion: openmoq.transport.pico= (the __FILE__-derived
+# default) must NOT select the sink. Presence under quic.picoquic= alone could
+# just be a root-level match.
+#
+# Usage: xlog_category_pico_smoke.sh <pico_evb_relay_server> <pico_evb_text_client> [port]
+
+set -uo pipefail
+
+SRV="${1:?usage: <pico_relay_server> <pico_text_client> [port]}"
+CLI="${2:?usage: <pico_relay_server> <pico_text_client> [port]}"
+PORT="${3:-14339}"
+
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "SKIP  quic.picoquic: openssl absent (needed to mint a throwaway cert)"
+  exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Match only DBG lines: folly's GlogStyleFormatter prefixes them 'V', while
+# INFO/WARN/ERR appear regardless of the selector and would give a false pass.
+has_dbg() { grep -Eq "^V[0-9].*(${1})"; }
+
+openssl req -x509 -newkey rsa:2048 -nodes -keyout "$WORK/key.pem" \
+  -out "$WORK/cert.pem" -days 1 -subj "/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost" >/dev/null 2>&1
+
+run_pico() {
+  local spec="$1" log="$WORK/pico.log"
+  "$SRV" -cert "$WORK/cert.pem" -key "$WORK/key.pem" \
+    -port "$PORT" -endpoint "/moq-relay" --logging="$spec" >/dev/null 2>"$log" &
+  local sp=$!
+  sleep 1
+  timeout 3 "$CLI" \
+    --connect_url "moqt://localhost:$PORT/moq-relay" \
+    --track_namespace "moq-date" --track_name "date" \
+    --cert_root "$WORK/cert.pem" --logging=INFO >/dev/null 2>/dev/null
+  sleep 0.3
+  kill "$sp" 2>/dev/null; wait "$sp" 2>/dev/null
+  cat "$log"
+}
+
+fail=0
+MARK='PicoQuicXLogSink\.cpp'
+
+if ! has_dbg "$MARK" <<<"$(run_pico 'DBG9')"; then
+  # installPicoQuicXLogSink() has no callers yet, so the sink never emits.
+  echo "SKIP  quic.picoquic: sink emitted no DBG at root — installer unwired (openmoq/moxygen#318)"
+  exit 0
+fi
+
+if has_dbg "$MARK" <<<"$(run_pico 'quic.picoquic=DBG9')"; then
+  echo "PASS  quic.picoquic=DBG9 selects /PicoQuicXLogSink.cpp/"
+else
+  echo "FAIL  quic.picoquic=DBG9 did NOT select the sink (XLOG_SET_CATEGORY_NAME not effective?)"
+  fail=1
+fi
+
+if has_dbg "$MARK" <<<"$(run_pico 'openmoq.transport.pico=DBG9')"; then
+  echo "FAIL  openmoq.transport.pico=DBG9 still selects the sink (override NOT applied)"
+  fail=1
+else
+  echo "PASS  openmoq.transport.pico=DBG9 excludes the sink (override applied → quic.picoquic)"
+fi
+
+[ "$fail" -eq 0 ] && echo "OK: picoquic XLOG category verified"
+exit "$fail"

--- a/standalone/test/xlog_category_smoke.sh
+++ b/standalone/test/xlog_category_smoke.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# xlog_category_smoke.sh — prove per-layer folly XLOG category filtering works:
+# for each layer, assert --logging=<layer>=DBG9 enables that layer's DBG lines
+# and excludes every other layer's.
+#
+# Behavioral rather than unit test by necessity: a category is a compile-time
+# property of each source file's __FILE__, and most of these sources are not
+# ours. A real client/server session is needed too — a client-less server never
+# handshakes, so fizz and mvfst would never emit.
+#
+# Layers not built on the XLOG backend, or not exercised by a session, SKIP.
+#
+# Usage: xlog_category_smoke.sh <moqdateserver> <moqtextclient> [base-port]
+
+set -uo pipefail
+
+DS="${1:?usage: <moqdateserver> <moqtextclient> [port]}"
+TC="${2:?usage: <moqdateserver> <moqtextclient> [port]}"
+PORT="${3:-14337}"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Match only DBG lines: folly's GlogStyleFormatter prefixes them 'V', while
+# INFO/WARN/ERR appear regardless of the selector and would give a false pass.
+# $1 = file-marker regex; log on stdin.
+has_dbg() { grep -Eq "^V[0-9].*(${1})"; }
+
+fail=0
+
+# assert_scoping <runner-fn> <marker-array-name>
+#   runner-fn: takes a --logging spec, prints the server's stderr
+#   marker array: layer -> regex matching a DBG line from that layer
+assert_scoping() {
+  local runner="$1"; local -n MARK="$2"
+  local -a layers=("${!MARK[@]}") active=()
+
+  # A marker absent at the root means that layer isn't on the XLOG backend or
+  # isn't exercised by this session — skip it, don't fail.
+  local root_out; root_out="$($runner 'DBG9')"
+  local L
+  for L in "${layers[@]}"; do
+    if has_dbg "${MARK[$L]}" <<<"$root_out"; then
+      active+=("$L")
+    else
+      echo "SKIP  $L: marker /${MARK[$L]}/ not emitted at root DBG9 (glog backend, not exercised, or stale marker)"
+    fi
+  done
+
+  # The exclusion half is the actual proof of scoping, and catches collisions
+  # between layers that end up sharing a category root.
+  local O out
+  for L in "${active[@]}"; do
+    out="$($runner "$L=DBG9")"
+    if has_dbg "${MARK[$L]}" <<<"$out"; then
+      echo "PASS  $L=DBG9 selects /${MARK[$L]}/"
+    else
+      echo "FAIL  $L=DBG9 did NOT select /${MARK[$L]}/ (category not rooted at '$L')"
+      fail=1
+    fi
+    for O in "${active[@]}"; do
+      [ "$O" = "$L" ] && continue
+      if has_dbg "${MARK[$O]}" <<<"$out"; then
+        echo "FAIL  $L=DBG9 leaked /${MARK[$O]}/ ($O not scoped out of '$L')"
+        fail=1
+      fi
+    done
+  done
+  [ "${#active[@]}" -gt 0 ] || echo "WARN  no layers active for $runner (nothing verified)"
+}
+
+# ── mvfst session: the six prefix-map layers on the default transport ─────────
+run_mvfst() {
+  local spec="$1" log="$WORK/mvfst.log"
+  "$DS" --insecure -port "$PORT" --logging="$spec" >/dev/null 2>"$log" &
+  local sp=$!
+  sleep 1
+  timeout 3 "$TC" --insecure \
+    --connect_url "https://localhost:$PORT/moq-date" \
+    --track_namespace "moq-date" --track_name "date" \
+    --logging=INFO >/dev/null 2>/dev/null
+  sleep 0.3
+  kill "$sp" 2>/dev/null; wait "$sp" 2>/dev/null
+  cat "$log"
+}
+
+# This session exercises moxygen, fizz and quic.mvfst. wangle (fires only behind
+# a TCP HTTP acceptor), proxygen (still on the glog backend here) and folly
+# (sparse XLOG use) SKIP today; they stay listed so they auto-activate once a
+# build or session reaches them.
+declare -A MVFST_MARK=(
+  [moxygen]='MoQSession\.cpp|MoQForwarder\.cpp'
+  [fizz]='AeadTokenCipher\.cpp|RecordLayer\.cpp|FizzServer|Fizz.*\.cpp'
+  [quic.mvfst]='QuicServer\.cpp|QuicTransport'
+  [wangle]='Acceptor\.cpp|ConnectionManager\.cpp'
+  [proxygen]='HQSession|HTTPTransaction|HQ.*Session'
+  [folly]='AsyncSocket\.cpp|AsyncUDPSocket\.cpp|EventBase\.cpp'
+)
+echo "── mvfst transport ──"
+assert_scoping run_mvfst MVFST_MARK
+
+[ "$fail" -eq 0 ] && echo "OK: per-layer XLOG category filtering verified"
+exit "$fail"


### PR DESCRIPTION
Makes **every** per-layer `--logging` selector work, and adds regression tests. Structured so the generic two-thirds can go upstream unchanged.

## Problem

Every bundled dependency compiles with an absolute `__FILE__`, so folly derives categories like `home.runner.work.moxygen...MoQSession`. Result: `--logging=moxygen=DBG4`, `quic.mvfst=DBG1`, `fizz=DBG1`, `quic.picoquic=DBG3` match **nothing** — only the root level (`--logging=DBG4`) works. The per-layer operator UX documented in moqx `docs/logging.md` and the `PicoQuicXLogSink` header is effectively dead.

folly does set `FOLLY_XLOG_STRIP_PREFIXES` for exactly this purpose, but with `${CMAKE_SOURCE_DIR}` — which in this build resolves to `standalone/` and is not a prefix of any dependency's sources, so it strips nothing.

## Changes

**1. Dependency category roots (`standalone/CMakeLists.txt`).** We don't own the deps' CMakeLists, so rewrite `__FILE__` from the consumer side: `-fmacro-prefix-map` before each `add_subdirectory`, stripping that dep's FetchContent source root. folly then derives `folly.*`, `fizz.*`, `wangle.*`, `quic.mvfst.*`, `proxygen.*`, `moxygen.*`.

`-fmacro-prefix-map` rather than `-ffile-prefix-map`: rewrites only `__FILE__`/macros so debug-info paths stay intact, and the maps stack across deps without macro-redefinition conflicts. mvfst is mapped under `quic/mvfst/` so it lands on the documented `quic.mvfst.*` root rather than claiming a bare `quic.*`.

**2. Regression test (`standalone/test/`, CTest `xlog_category_roots`).** Drives a real date-server/text-client session and asserts, per layer, that its selector enables that layer's DBG lines and **excludes** the others — the exclusion is the actual proof of scoping. Matches only `V`-prefixed (DBG) lines so INFO/WARN/ERR can't mask a broken category. Layers still on the glog backend, or not exercised by the session, SKIP rather than fail.

Registered only when the sample binaries exist (`TARGET moqdateserver AND TARGET moqtextclient`) rather than gating on `BUILD_SAMPLES`, which isn't defined in every configuration of this build.

`standalone/test/CMakeLists.txt` ends with `include(.../local.cmake OPTIONAL)` so a downstream tree can register its own tests without editing an upstream-owned file.

**3. picoquic bridge (`PicoQuicXLogSink.cpp`) — this fork only.** The sink used bare `XLOG()`, so its events landed under `openmoq.transport.pico.*` instead of the advertised `quic.picoquic.*`. `XLOG_SET_CATEGORY_NAME("quic.picoquic")` names the category explicitly — the right model for a bridge, and it needs no build-side prefix map. Its test rides the `local.cmake` seam, and since we're the tree that actually has a `local.cmake`, this commit also negates it against the blanket `*.cmake` ignore rule.

## Relationship to upstream #207

facebookexperimental/moxygen#207 (landed as `ceab51c0`, since synced) fixes `FOLLY_XLOG_STRIP_PREFIXES` in moxygen's **repo-root** `CMakeLists.txt`. That does not reach this build: `standalone/CMakeLists.txt` is its own `project()` and adds the inner `moxygen/` directory directly, so the repo-root file is never processed. The `moxygen` map here is required, not redundant.

Upstream's own `standalone/` build has the same gap. Commits 1 and 2 apply to it unchanged and are headed there as a separate PR; commit 3 is fork-only, since `moxygen/openmoq/` doesn't exist upstream.

Separately, folly's `CMakeLists.txt` sets `FOLLY_XLOG_STRIP_PREFIXES` with `${CMAKE_SOURCE_DIR}` where its own comment intends folly's root. `${CMAKE_CURRENT_SOURCE_DIR}` would fix `folly.*` for every embedded consumer and is a no-op when folly is top-level — worth a separate upstream PR.

## Test plan

`ctest -R xlog_category` on a local standalone build (`BUILD_PICOQUIC=ON`, `MOXYGEN_LOGGING_FOLLY_XLOG=ON`):

```
── mvfst transport ──
PASS  moxygen=DBG9 selects /MoQSession\.cpp|MoQForwarder\.cpp/
PASS  quic.mvfst=DBG9 selects /QuicServer\.cpp|QuicTransport/
PASS  fizz=DBG9 selects /AeadTokenCipher\.cpp|RecordLayer\.cpp|FizzServer|Fizz.*\.cpp/
SKIP  folly / wangle / proxygen  (not exercised by this session, or still on glog)
SKIP  quic.picoquic: installer unwired (#318)
```

Negative control: the same test against pre-fix binaries **FAILs** `moxygen` scoping (exit 1), confirming it detects a regression rather than passing vacuously.

Manual checks beyond what the test asserts, counting `V`-prefixed lines from the same session (the test itself only exercises bare `<layer>=DBG9`):

| selector | MoQSession | MoQForwarder | mvfst |
|---|---|---|---|
| `moxygen.MoQSession=DBG4` | 24 | 0 | 0 |
| `moxygen=DBG4` | 24 | 5 | 0 |
| `moxygen=DBG4,quic.mvfst=WARN` | 24 | 5 | 0 |
| `moxygen=DBG1` | 20 | 3 | 0 |
| `moxygen=INFO` | 0 | 0 | 0 |

Sub-category scoping, parent-selects-children, multi-selector specs, and level granularity all behave.

**Coverage limits, stated plainly:** this proves 3 of the 7 documented selectors (`moxygen`, `quic.mvfst`, `fizz`). `folly`, `wangle` and `proxygen` are rooted but never fire in a date-server session, and `quic.picoquic` is blocked on #318 — so those four are unverified, not verified-working.

## Not closed by this PR

- #318 — `installPicoQuicXLogSink()` has zero callers, so `quic.picoquic` stays inert until the installer is wired.
- proxygen is still on the glog backend in this build, so `proxygen=` is inert regardless of category rooting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/312)
<!-- Reviewable:end -->
