### PR TITLE
MoQForwarder: restore passive-subscriber guard in duplicate beginSubgroup

### DIFF
--- a/moxygen/relay/MoQForwarder.cpp
+++ b/moxygen/relay/MoQForwarder.cpp
@@ -630,10 +630,20 @@ MoQForwarder::beginSubgroup(
       if (it != sub->subgroups.end() && it->second) {
         it->second->reset(ResetStreamErrorCode::CANCELLED);
         sub->subgroups.erase(it);
-        anyReset = true;
+        // Passive subscribers (e.g. the relay's own top-N/cache observer chain)
+        // are not real downstream consumers: they never stop_sending, so they
+        // must not mask the "no active consumers" signal. Reset their stale
+        // subgroup but do not count them toward anyReset, otherwise a duplicate
+        // subgroup would never propagate CANCELLED back to the publisher once
+        // all real consumers have stop_sent.
+        if (!sub->passive) {
+          anyReset = true;
+        }
       } else if (
-          it == sub->subgroups.end() && sub->trackConsumer &&
+          !sub->passive && it == sub->subgroups.end() && sub->trackConsumer &&
           checkRange(*sub) && sub->checkShouldForward()) {
+        // Passive subscribers can't renew interest either - only a real
+        // downstream subscriber counts as a reopen candidate.
         anyReopenCandidate = true;
       }
     }

--- a/moxygen/relay/test/OpenMOQForwarderTest.cpp
+++ b/moxygen/relay/test/OpenMOQForwarderTest.cpp
@@ -284,6 +284,102 @@ TEST_F(OpenMOQForwarderTest, DuplicateChannelSubscriberSameExecIsNoOp) {
   EXPECT_EQ(forwarder->numForwardingSubscribers(), 1u);
 }
 
+// Test: Once all real subscribers have tombstoned a subgroup, duplicate
+// beginSubgroup returns CANCELLED - a passive observer's reset doesn't mask it.
+TEST_F(OpenMOQForwarderTest, PassiveResetDoesNotMaskDuplicateSubgroupCancel) {
+  auto forwarder = std::make_shared<MoQForwarder>(kOpenFwdTestTrackName);
+  auto realSession = createMockSession();
+  auto passiveSession = createMockSession();
+  auto realConsumer = createMockConsumer();
+  auto passiveConsumer = createMockConsumer();
+
+  std::shared_ptr<MockSubgroupConsumer> realSg;
+  EXPECT_CALL(*realConsumer, beginSubgroup(0, 0, _, _))
+      .WillOnce(
+          [this, &realSg](uint64_t, uint64_t, uint8_t, BeginSubgroupOptions) {
+            realSg = createMockSubgroupConsumer();
+            // Simulate stop_sending: soft error tombstones the subgroup.
+            EXPECT_CALL(*realSg, object(0, _, _, false))
+                .WillOnce(Return(
+                    folly::makeUnexpected(MoQPublishError(
+                        MoQPublishError::CANCELLED, "STOP_SENDING"))));
+            return folly::makeExpected<
+                MoQPublishError,
+                std::shared_ptr<SubgroupConsumer>>(realSg);
+          });
+
+  std::shared_ptr<MockSubgroupConsumer> passiveSg;
+  EXPECT_CALL(*passiveConsumer, beginSubgroup(0, 0, _, _))
+      .WillOnce([this, &passiveSg](
+                    uint64_t, uint64_t, uint8_t, BeginSubgroupOptions) {
+        passiveSg = createMockSubgroupConsumer();
+        EXPECT_CALL(*passiveSg, object(0, _, _, false))
+            .WillOnce(Return(folly::unit));
+        // The duplicate resets the passive observer's stale consumer...
+        EXPECT_CALL(*passiveSg, reset(ResetStreamErrorCode::CANCELLED));
+        return folly::
+            makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
+                passiveSg);
+      });
+
+  auto realHandle =
+      addSubscriber(*forwarder, realSession, realConsumer, RequestID(1));
+  ASSERT_NE(realHandle, nullptr);
+  auto passiveHandle = forwarder->addSubscriber(
+      passiveSession, /*forward=*/true, passiveConsumer, /*passive=*/true);
+  ASSERT_NE(passiveHandle, nullptr);
+
+  auto pubSg = forwarder->beginSubgroup(0, 0, 0).value();
+  EXPECT_TRUE(pubSg->object(0, test::makeBuf(4)).hasValue());
+
+  // ...but must not count toward anyReset: CANCELLED propagates.
+  auto dupRes = forwarder->beginSubgroup(0, 0, 0);
+  ASSERT_TRUE(dupRes.hasError());
+  EXPECT_EQ(dupRes.error().code, MoQPublishError::CANCELLED);
+}
+
+// Test: A passive subscriber with no subgroup state is not a reopen candidate.
+TEST_F(OpenMOQForwarderTest, PassiveDoesNotCountAsReopenCandidate) {
+  auto forwarder = std::make_shared<MoQForwarder>(kOpenFwdTestTrackName);
+  auto realSession = createMockSession();
+  auto passiveSession = createMockSession();
+  auto realConsumer = createMockConsumer();
+  auto passiveConsumer = createMockConsumer();
+
+  std::shared_ptr<MockSubgroupConsumer> realSg;
+  EXPECT_CALL(*realConsumer, beginSubgroup(0, 0, _, _))
+      .WillOnce(
+          [this, &realSg](uint64_t, uint64_t, uint8_t, BeginSubgroupOptions) {
+            realSg = createMockSubgroupConsumer();
+            EXPECT_CALL(*realSg, object(0, _, _, false))
+                .WillOnce(Return(
+                    folly::makeUnexpected(MoQPublishError(
+                        MoQPublishError::CANCELLED, "STOP_SENDING"))));
+            return folly::makeExpected<
+                MoQPublishError,
+                std::shared_ptr<SubgroupConsumer>>(realSg);
+          });
+  // The passive observer joins after the subgroup's objects were delivered
+  // (object delivery lazily opens subgroups for earlier joiners), so it has
+  // no subgroup entry; it must not be offered the duplicate subgroup.
+  EXPECT_CALL(*passiveConsumer, beginSubgroup(_, _, _, _)).Times(0);
+
+  auto realHandle =
+      addSubscriber(*forwarder, realSession, realConsumer, RequestID(1));
+  ASSERT_NE(realHandle, nullptr);
+
+  auto pubSg = forwarder->beginSubgroup(0, 0, 0).value();
+  EXPECT_TRUE(pubSg->object(0, test::makeBuf(4)).hasValue());
+
+  auto passiveHandle = forwarder->addSubscriber(
+      passiveSession, /*forward=*/true, passiveConsumer, /*passive=*/true);
+  ASSERT_NE(passiveHandle, nullptr);
+
+  auto dupRes = forwarder->beginSubgroup(0, 0, 0);
+  ASSERT_TRUE(dupRes.hasError());
+  EXPECT_EQ(dupRes.error().code, MoQPublishError::CANCELLED);
+}
+
 TEST_F(OpenMOQForwarderTest, ChannelSubscriberDrainsWhenSubgroupsOpen) {
   auto forwarder = std::make_shared<MoQForwarder>(kOpenFwdTestTrackName);
   auto consumer = createMockConsumer();


### PR DESCRIPTION
## Problem

moqx sync PR openmoq/moqx#499 fails on all 3 platforms: `DuplicateSubgroupCancelledWhenNoActiveConsumers/LocalForwarderMT` segfaults (ASAN teardown use-after-free).

Root cause: the sync-conflict resolution in #324 (pin `0d9f3af`) took upstream `e848acf5` ("Gate subgroup reopen on v18 forward resume") verbatim for the duplicate-subgroup block in `MoQForwarder::beginSubgroup`, dropping the openmoq guard from `12b24a60`: when a duplicate subgroup resets a **passive** subscriber's stale consumer (the relay's top-N/cache observer chain), it must not count toward `anyReset`. Without the guard, the passive local-forwarder subscriber masks the "no active consumers" signal, the duplicate `beginSubgroup` succeeds instead of returning CANCELLED, and the moqx test's `dupRes.error()` on a success value throws, skipping cleanup and segfaulting in teardown.

Same failure pattern as the recurring TRACK_FILTER `kParamAllowlist` sync casualty.

## Fix

- `MoQForwarder::beginSubgroup`: restore the `!sub->passive` guard on `anyReset`, and exclude passive subscribers from upstream's new `anyReopenCandidate` as well (a passive sub with no subgroup entry would otherwise mask CANCELLED the same way). Reconciles our passive-subscriber feature with upstream's v18 reopen logic rather than reverting it.
- Two regression tests in `OpenMOQForwarderTest` so moxygen's own CI catches the next sync that drops this guard, instead of it surfacing two repos downstream in moqx.

## Validation

- `OpenMOQForwarderTest`: 13/13 pass with the fix; both new tests fail against the unguarded post-sync code (verified by stashing the fix).
- Upstream `MoQForwarderTest`: 26/26 pass — the v18 forward-resume reopen behavior is unchanged for real subscribers.

## Follow-up

On merge, snapshot publish → bump the moxygen pin on the existing `sync-moxygen/*` branch in moqx (keeping the compile fix already there) so #499 goes green and auto-merges.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/326)
<!-- Reviewable:end -->
