### PR TITLE
version release: fix finalize isLatest check

### DIFF
--- a/.github/workflows/omoq-version-release.yml
+++ b/.github/workflows/omoq-version-release.yml
@@ -333,8 +333,8 @@ jobs:
             xargs -0 -n1 -P 6 -I{} gh release upload "$TAG" --repo "$REPO" {} --clobber
 
   # ════════════════════════════════════════════════════════════════════════════
-  # Finalize: flip draft → published once all assets are up. Runs only if
-  # both upload jobs succeeded.
+  # Finalize: confirm the release is fully published once all assets are
+  # up. Runs only if both upload jobs succeeded.
   # ════════════════════════════════════════════════════════════════════════════
 
   finalize:
@@ -359,4 +359,8 @@ jobs:
           # would mark a hotfix patch from a release/vM.m branch as
           # latest even when a newer vM.(m+1) line exists.
           echo "Released: $TAG"
-          gh release view "$TAG" --repo "$REPO" --json isLatest,isPrerelease,name --jq '"isLatest=\(.isLatest) isPrerelease=\(.isPrerelease) name=\(.name)"'
+          # isLatest is not a --json field on `gh release view` (only on
+          # `gh release list`), so derive it from the releases/latest API.
+          gh release view "$TAG" --repo "$REPO" --json isPrerelease,name --jq '"isPrerelease=\(.isPrerelease) name=\(.name)"'
+          LATEST=$(gh api "repos/$REPO/releases/latest" --jq .tag_name)
+          echo "isLatest=$([ "$LATEST" = "$TAG" ] && echo true || echo false) (latest=$LATEST)"


### PR DESCRIPTION
Fixes #330.

The `Confirm release published` step in the finalize job queried `gh release view --json isLatest,...`, but `isLatest` is not a supported `--json` field on `gh release view` (it only exists on `gh release list`), so the step always exited 1 — seen on the v0.2.0 run (https://github.com/openmoq/moxygen/actions/runs/30036284298), where the release itself published fine with all assets.

Changes:
- Keep `isPrerelease`/`name` from `gh release view`; derive latest-ness by comparing `$TAG` against `gh api repos/$REPO/releases/latest`. Still no `--latest` forcing — GitHub's auto-latest algorithm stays authoritative (matters for hotfix patches from `release/vM.m` branches).
- Fix the stale finalize job header comment ("flip draft → published" → the step only confirms; the release is published earlier in the flow).

Tested locally against v0.2.0:
```
isPrerelease=false name=moxygen 0.2.0
isLatest=true (latest=v0.2.0)
```
YAML validated. No release artifacts affected; v0.2.0 needs no re-cut.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/331)
<!-- Reviewable:end -->
