### PR TITLE
Count active subscriptions only once they go active

### DIFF
--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -1372,6 +1372,12 @@ class MoQSession::TrackPublisherImpl : public MoQSession::PublisherImpl,
       deliveryTimeoutManager_.setSubscriberTimeout(
           std::chrono::milliseconds(*timeoutValue));
     }
+    session_->beginSubscriptionStat(*this);
+  }
+
+  // A deferred publishDone stops writes but still sends SUBSCRIBE_OK.
+  bool publishEnded() const {
+    return isDone() || pendingPublishDone_.has_value();
   }
 
   void publishSent(const PublishRequest& publish) {
@@ -1391,6 +1397,7 @@ class MoQSession::TrackPublisherImpl : public MoQSession::PublisherImpl,
     if (timeout.has_value() && shouldApplyDeliveryTimeout(timeout->count())) {
       deliveryTimeoutManager_.setPublisherTimeout(*timeout);
     }
+    session_->beginSubscriptionStat(*this);
   }
 
   void setForward(bool forward) {
@@ -1491,8 +1498,6 @@ class MoQSession::TrackPublisherImpl : public MoQSession::PublisherImpl,
       std::shared_ptr<StreamPublisherImpl>>
       subgroups_;
   uint64_t streamCount_{0};
-  enum class State { OPEN, DONE };
-  State state_{State::OPEN};
   bool forward_;
   std::shared_ptr<DeliveryCallback> deliveryCallback_;
   MoQDeliveryTimeoutManager deliveryTimeoutManager_;
@@ -1672,7 +1677,7 @@ MoQSession::TrackPublisherImpl::beginSubgroup(
   }
 
   auto wt = getWebTransport();
-  if (!wt || state_ != State::OPEN) {
+  if (!wt || publishEnded()) {
     XLOG(ERR) << "Trying to publish after publishDone";
     return folly::makeUnexpected(MoQPublishError(
         MoQPublishError::API_ERROR, "Publish after publishDone"));
@@ -1724,7 +1729,7 @@ MoQSession::TrackPublisherImpl::beginSubgroup(
 folly::Expected<folly::SemiFuture<folly::Unit>, MoQPublishError>
 MoQSession::TrackPublisherImpl::awaitStreamCredit() {
   auto wt = getWebTransport();
-  if (!wt || state_ != State::OPEN) {
+  if (!wt || publishEnded()) {
     return folly::makeUnexpected(MoQPublishError(
         MoQPublishError::API_ERROR, "awaitStreamCredit after publishDone"));
   }
@@ -1830,7 +1835,7 @@ MoQSession::TrackPublisherImpl::datagram(
         "Cannot send datagrams for subscriptions with forward flag set to false"));
   }
   auto wt = getWebTransport();
-  if (!wt || state_ != State::OPEN) {
+  if (!wt || publishEnded()) {
     XLOG(ERR) << "Trying to publish after publishDone";
     return folly::makeUnexpected(MoQPublishError(
         MoQPublishError::API_ERROR, "Publish after publishDone"));
@@ -1878,11 +1883,10 @@ MoQSession::TrackPublisherImpl::datagram(
 
 folly::Expected<folly::Unit, MoQPublishError>
 MoQSession::TrackPublisherImpl::publishDone(PublishDone pubDone) {
-  if (state_ != State::OPEN || !session_) {
+  if (publishEnded() || !session_) {
     return folly::makeUnexpected(MoQPublishError(
         MoQPublishError::API_ERROR, "publishDone twice or after close"));
   }
-  state_ = State::DONE;
   pubDone.requestID = requestID_;
   if (!subscriptionHandle_) {
     // publishDone called from inside the subscribe handler,
@@ -2410,7 +2414,7 @@ void MoQSession::cleanup() {
     if (const auto& control = pubTrack->bidiControl()) {
       control->disarmOnPeerTermination();
     }
-    MOQ_PUBLISHER_STATS(publisherStatsCallback_, onSubscriptionEnd);
+    endSubscriptionStat(*pubTrack);
     pubTrack->terminatePublish(
         PublishDone(
             {requestID,
@@ -4226,15 +4230,16 @@ void MoQSession::onUnsubscribe(Unsubscribe unsubscribe) {
               << " sess=" << this;
     return;
   }
+  // Holds a ref so the erase below can't destroy it out from under the stat.
   auto trackPublisher =
-      dynamic_cast<TrackPublisherImpl*>(pubTrackIt->second.get());
+      std::dynamic_pointer_cast<TrackPublisherImpl>(pubTrackIt->second);
   if (!trackPublisher) {
     XLOG(ERR) << "RequestID in Unsubscribe is for a FETCH, id="
               << unsubscribe.requestID << " sess=" << this;
   } else {
     trackPublisher->unsubscribe();
     if (pubTracks_.erase(unsubscribe.requestID)) {
-      MOQ_PUBLISHER_STATS(publisherStatsCallback_, onSubscriptionEnd);
+      endSubscriptionStat(*trackPublisher);
       retireRequestID(/*signalWriteLoop=*/true);
       checkForCloseOnDrain();
     } // else, the caller invoked publishDone, which isn't needed but fine
@@ -4271,7 +4276,6 @@ void MoQSession::onPublishOk(PublishOk publishOk) {
         std::static_pointer_cast<TrackPublisherImpl>(trackIt->second);
     trackPublisher->onPublishOk(publishOk);
     pendingPublishTracks_.erase(trackIt->second->fullTrackName());
-    MOQ_PUBLISHER_STATS(publisherStatsCallback_, onSubscriptionBegin);
   }
   // No disarm: PUBLISH_OK is non-terminal; publishDone's flush(fin) disarms.
 
@@ -5755,7 +5759,6 @@ folly::coro::Task<Publisher::SubscribeResult> MoQSession::subscribe(
 void MoQSession::sendSubscribeOk(const SubscribeOk& subOk, ReplyContext& ctx) {
   XLOG(DBG1) << __func__ << " sess=" << this;
   MOQ_PUBLISHER_STATS(publisherStatsCallback_, onSubscribeSuccess);
-  MOQ_PUBLISHER_STATS(publisherStatsCallback_, onSubscriptionBegin);
   auto res = moqFrameWriter_.writeSubscribeOk(ctx.writeBuf(), subOk);
   if (!res) {
     XLOG(ERR) << "writeSubscribeOk failed sess=" << this;
@@ -5846,6 +5849,18 @@ void MoQSession::unsubscribe(
   checkForCloseOnDrain();
 }
 
+void MoQSession::beginSubscriptionStat(PublisherImpl& pubTrack) {
+  if (pubTrack.markEstablished()) {
+    MOQ_PUBLISHER_STATS(publisherStatsCallback_, onSubscriptionBegin);
+  }
+}
+
+void MoQSession::endSubscriptionStat(PublisherImpl& pubTrack) {
+  if (pubTrack.markDone()) {
+    MOQ_PUBLISHER_STATS(publisherStatsCallback_, onSubscriptionEnd);
+  }
+}
+
 void MoQSession::sendPublishDone(const PublishDone& pubDone) {
   XLOG(DBG1) << __func__ << " sess=" << this;
   MOQ_PUBLISHER_STATS(
@@ -5856,7 +5871,7 @@ void MoQSession::sendPublishDone(const PublishDone& pubDone) {
               << " sess=" << this;
     return;
   }
-  MOQ_PUBLISHER_STATS(publisherStatsCallback_, onSubscriptionEnd);
+  endSubscriptionStat(*it->second);
   auto* ctx = it->second->replyContext();
   SCOPE_EXIT {
     pubTracks_.erase(it);

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -477,6 +477,32 @@ class MoQSession : public Subscriber,
       return bidiControl_;
     }
 
+    // Only ESTABLISHED holds a +1 on the active-subscription gauge; FETCH
+    // publishers never leave PENDING.
+    enum class State { PENDING, ESTABLISHED, DONE };
+
+    State state() const {
+      return state_;
+    }
+    bool isDone() const {
+      return state_ == State::DONE;
+    }
+    // True on the PENDING -> ESTABLISHED edge, so begin fires exactly once.
+    bool markEstablished() {
+      if (state_ != State::PENDING) {
+        return false;
+      }
+      state_ = State::ESTABLISHED;
+      return true;
+    }
+    // True only if the subscription was counted, so teardown can't decrement
+    // one that never went active.
+    bool markDone() {
+      bool wasEstablished = (state_ == State::ESTABLISHED);
+      state_ = State::DONE;
+      return wasEstablished;
+    }
+
    protected:
     MoQSession* session_{nullptr};
     FullTrackName fullTrackName_;
@@ -490,6 +516,7 @@ class MoQSession : public Subscriber,
     std::optional<uint8_t> publisherPriority_;
     std::shared_ptr<ReplyContext> replyContext_;
     std::shared_ptr<BidiStreamControl> bidiControl_;
+    State state_{State::PENDING};
   };
 
   void onNewUniStream(
@@ -679,6 +706,9 @@ class MoQSession : public Subscriber,
     requestUpdateError(reqError, existingReqID);
   }
   void sendPublishDone(const PublishDone& pubDone);
+
+  void beginSubscriptionStat(PublisherImpl& pubTrack);
+  void endSubscriptionStat(PublisherImpl& pubTrack);
 
   folly::coro::Task<void> handleFetch(
       Fetch fetch,

--- a/moxygen/test/MoQSessionFetchTests.cpp
+++ b/moxygen/test/MoQSessionFetchTests.cpp
@@ -759,3 +759,40 @@ CO_TEST_P_X(Draft18Test, NoFetchCancelAfterFetchComplete) {
   co_await folly::coro::co_reschedule_on_current_executor;
   clientSession_->close(SessionCloseErrorCode::NO_ERROR);
 }
+
+// Regression: FETCH publishers live in pubTracks_ but never fire
+// onSubscriptionBegin, so session close must not decrement the active gauge.
+CO_TEST_P_X(MoQSessionTest, NoSubscriptionEndForInFlightFetchAtClose) {
+  co_await setupMoQSession();
+
+  folly::coro::Baton serverSawFetch;
+  folly::coro::Baton releaseHandler;
+  EXPECT_CALL(*serverPublisher, fetch(_, _))
+      .WillOnce([&](Fetch fetch, auto /*pub*/) -> TaskFetchResult {
+        serverSawFetch.post();
+        co_await releaseHandler;
+        co_return makeFetchOkResult(fetch, AbsoluteLocation{0, 0});
+      });
+
+  EXPECT_CALL(*serverPublisherStatsCallback_, onSubscriptionBegin()).Times(0);
+  EXPECT_CALL(*serverPublisherStatsCallback_, onSubscriptionEnd()).Times(0);
+
+  folly::coro::Baton fetchReturned;
+  folly::coro::co_withExecutor(
+      MoQExecutor_.get(),
+      folly::coro::co_invoke([&]() -> folly::coro::Task<void> {
+        co_await clientSession_->fetch(
+            getFetch({0, 0}, {0, 1}), fetchCallback_);
+        fetchReturned.post();
+      }))
+      .start();
+
+  // The FetchPublisherImpl is in the server's pubTracks_ and stays there:
+  // the handler never returns, so neither fetchOk nor fetchError fires.
+  co_await serverSawFetch;
+  serverSession_->close(SessionCloseErrorCode::NO_ERROR);
+  releaseHandler.post();
+  // The detached coro captures test locals by reference; it must finish first.
+  co_await fetchReturned;
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+}

--- a/moxygen/test/MoQSessionPublishTests.cpp
+++ b/moxygen/test/MoQSessionPublishTests.cpp
@@ -1202,3 +1202,59 @@ CO_TEST_P_X(MoQSessionTest, PublishDuplicatesPendingSubscribe) {
 
   clientSession_->close(SessionCloseErrorCode::NO_ERROR);
 }
+
+// Regression: a PUBLISH still awaiting PUBLISH_OK is in pubTracks_ but was
+// never counted, so session close must not decrement the active gauge.
+CO_TEST_P_X(MoQSessionTest, NoSubscriptionEndForPublishPendingOkAtClose) {
+  co_await setupMoQSessionForPublish(initialMaxRequestID_);
+
+  folly::coro::Baton replyBlocked;
+  EXPECT_CALL(*serverSubscriber, publish(_, _))
+      .WillOnce(
+          [&replyBlocked](
+              PublishRequest actualPub, std::shared_ptr<SubscriptionHandle>)
+              -> Subscriber::PublishResult {
+            auto consumer = std::make_shared<MockTrackConsumer>();
+            EXPECT_CALL(*consumer, setTrackAlias(_))
+                .WillRepeatedly(testing::Return(
+                    folly::Expected<folly::Unit, MoQPublishError>(
+                        folly::unit)));
+            EXPECT_CALL(*consumer, publishDone(_))
+                .WillRepeatedly(testing::Return(folly::unit));
+            auto requestID = actualPub.requestID;
+            return Subscriber::PublishConsumerAndReplyTask{
+                std::static_pointer_cast<TrackConsumer>(consumer),
+                folly::coro::co_invoke(
+                    [&replyBlocked, requestID]()
+                        -> folly::coro::Task<
+                            folly::Expected<PublishOk, PublishError>> {
+                      co_await replyBlocked;
+                      co_return folly::makeUnexpected(PublishError{
+                          requestID,
+                          PublishErrorCode::INTERNAL_ERROR,
+                          "never accepted"});
+                    })};
+          });
+
+  EXPECT_CALL(*clientPublisherStatsCallback_, onSubscriptionBegin()).Times(0);
+  EXPECT_CALL(*clientPublisherStatsCallback_, onSubscriptionEnd()).Times(0);
+
+  auto handle = makePublishHandle();
+  auto result = clientSession_->publish(
+      PublishRequest{
+          RequestID(0),
+          FullTrackName{TrackNamespace{{"test"}}, "test-track"},
+          TrackAlias(100),
+          GroupOrder::Default,
+          AbsoluteLocation{0, 100},
+          true,
+      },
+      handle);
+  EXPECT_TRUE(result.hasValue());
+
+  // PUBLISH is on the wire and in pubTracks_; PUBLISH_OK never arrives.
+  co_await rescheduleN(5);
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+  serverSession_->close(SessionCloseErrorCode::NO_ERROR);
+  replyBlocked.post();
+}


### PR DESCRIPTION
pubActiveSubscriptions decremented for pubTracks_ entries that never incremented it: a PUBLISH awaiting PUBLISH_OK, or an in-flight FETCH, both drove the gauge negative at session close.

TrackPublisherImpl's OPEN/DONE state moves up to PublisherImpl, and OPEN splits into PENDING and ESTABLISHED. Only ESTABLISHED holds a +1, so the three teardown paths decrement exactly what they counted. FETCH publishers never leave PENDING.

Fixes: openmoq/moqx#538

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/349)
<!-- Reviewable:end -->
