### PR TITLE
standalone: accept libcares_static.a for Ubuntu 24.04 publish

### DIFF
--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -74,6 +74,9 @@ endif()
 
 find_package(ZLIB REQUIRED)
 find_library(ZSTD_LIBRARY NAMES zstd)
+# Ubuntu 24.04 names the static lib libcares_static.a; seed the cache var so
+# fbcode_builder's FindCares (NAMES cares only) accepts it under .a-only search.
+find_library(CARES_LIBRARIES NAMES cares cares_static)
 
 # =============================================================================
 # Read pinned commit hashes from github_hashes (same as getdeps uses)


### PR DESCRIPTION
Hotfix for the `publish (ubuntu-24.04-amd64)` failure on main ([run 31062525386](https://github.com/openmoq/moxygen/actions/runs/31062525386/job/92497812238)) introduced by #309.

**Cause:** Ubuntu 24.04's `libc-ares-dev` ships the static library as `libcares_static.a` (jammy ships `libcares.a`). Publish builds use `BUNDLE_DEPS=ON`, which restricts `find_library` to `.a` on Linux, and fbcode_builder's `FindCares.cmake` only searches `NAMES cares` — so proxygen configure failed with `Could NOT find Cares (missing: CARES_LIBRARIES)`.

**Fix:** pre-seed the `CARES_LIBRARIES` cache variable with `find_library(CARES_LIBRARIES NAMES cares cares_static)` before dependency configure. `FindCares`'s own `find_library` then hits the cache, and its `.a$` check still classifies `libcares_static.a` as a static import.

**Note:** PR CI does not exercise the publish matrix (it only lives in `ci main`), so checks here prove nothing about this fix — it is being validated locally in an `ubuntu:24.04` container running the publish job's exact configure step (`BUNDLE_DEPS=ON`), results to follow in a comment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/351)
<!-- Reviewable:end -->
