### PR TITLE
setup: let applications add SETUP parameters

### DIFF
--- a/moxygen/MoQClientBase.cpp
+++ b/moxygen/MoQClientBase.cpp
@@ -196,6 +196,9 @@ Setup MoQClientBase::getClientSetup(const std::optional<std::string>& path) {
         SetupParameter(folly::to_underlying(SetupKey::AUTHORITY), authority));
   }
 
+  // Last, so the application can override anything set above.
+  applySetupParameters(clientSetup.params, setupParams_);
+
   return clientSetup;
 }
 

--- a/moxygen/MoQClientBase.h
+++ b/moxygen/MoQClientBase.h
@@ -20,6 +20,7 @@
 #include <moxygen/mlog/MLogger.h>
 #include <functional>
 #include <memory>
+#include <vector>
 
 namespace moxygen {
 
@@ -129,6 +130,13 @@ class MoQClientBase {
     earlyDataHandler_ = handler;
   }
 
+  // Adds a parameter to every SETUP, replacing (not duplicating) any parameter
+  // this class would otherwise send with the same key. Call before setting up
+  // the session.
+  void addSetupParameter(SetupParameter parameter) {
+    setupParams_.emplace_back(std::move(parameter));
+  }
+
   void goaway(const Goaway& goaway);
   std::shared_ptr<MLogger> logger_ = nullptr;
 
@@ -154,6 +162,7 @@ class MoQClientBase {
 
   std::shared_ptr<MoQExecutor> exec_;
   proxygen::URL url_;
+  std::vector<SetupParameter> setupParams_;
   SessionFactory sessionFactory_;
   std::shared_ptr<proxygen::QuicWebTransport> quicWebTransport_;
   std::shared_ptr<proxygen::QuicWtSession> quicWtSession_;

--- a/moxygen/MoQServerBase.cpp
+++ b/moxygen/MoQServerBase.cpp
@@ -76,6 +76,8 @@ Setup MoQServerBase::makeServerSetup() {
       Parameter{
           folly::to_underlying(SetupKey::MAX_AUTH_TOKEN_CACHE_SIZE),
           kDefaultMaxAuthTokenCacheSize});
+  // Last, so the application can override anything set above.
+  applySetupParameters(setup.params, setupParams_);
   return setup;
 }
 

--- a/moxygen/MoQServerBase.h
+++ b/moxygen/MoQServerBase.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 namespace moxygen {
 
@@ -67,6 +68,13 @@ class MoQServerBase : public MoQSession::ServerSetupCallback,
    */
   void setMLoggerFactory(std::shared_ptr<MLoggerFactory> factory);
 
+  // Adds a parameter to every SETUP, replacing (not duplicating) any parameter
+  // makeServerSetup() would otherwise send with the same key. Call before
+  // accepting sessions.
+  void addSetupParameter(SetupParameter parameter) {
+    setupParams_.emplace_back(std::move(parameter));
+  }
+
   // ServerSetupCallback overrides
   folly::Try<Setup> onClientSetup(
       Setup clientSetup,
@@ -104,6 +112,7 @@ class MoQServerBase : public MoQSession::ServerSetupCallback,
 
   std::unordered_set<std::string> endpoints_;
   std::shared_ptr<MLoggerFactory> mLoggerFactory_;
+  std::vector<SetupParameter> setupParams_;
 };
 
 } // namespace moxygen

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -2706,9 +2706,13 @@ folly::Expected<folly::Unit, quic::TransportErrorCode> MoQSession::sendSetup(
 
   auto maxRequestID = getMaxRequestIDIfPresent(setup.params);
 
-  setup.params.insertParam(SetupParameter(
-      {folly::to_underlying(SetupKey::MOQT_IMPLEMENTATION),
-       getMoQTImplementationString()}));
+  // Don't duplicate a key the application already set via addSetupParameter().
+  if (!setup.params.hasParam(
+          folly::to_underlying(SetupKey::MOQT_IMPLEMENTATION))) {
+    setup.params.insertParam(SetupParameter(
+        {folly::to_underlying(SetupKey::MOQT_IMPLEMENTATION),
+         getMoQTImplementationString()}));
+  }
 
   uint64_t setupSerializationVersion = kVersionDraft14;
   if (negotiatedVersion_) {

--- a/moxygen/MoQTypes.cpp
+++ b/moxygen/MoQTypes.cpp
@@ -470,4 +470,16 @@ Fetch::Fetch(
   }
 }
 
+void applySetupParameters(
+    SetupParameters& params,
+    const std::vector<SetupParameter>& extraParams) {
+  for (const auto& param : extraParams) {
+    params.eraseAllParamsOfType(param.key);
+    auto result = params.insertParam(param);
+    if (result.hasError()) {
+      XLOG(ERR) << "Setup param not allowed, key=" << param.key;
+    }
+  }
+}
+
 } // namespace moxygen

--- a/moxygen/MoQTypes.h
+++ b/moxygen/MoQTypes.h
@@ -640,6 +640,28 @@ class Parameters {
     return params_.at(position);
   }
 
+  // Returns the first parameter with `key`, or nullptr. Invalidated by any
+  // subsequent mutation.
+  const Parameter* getFirstParam(uint64_t key) const {
+    auto it = std::find_if(
+        params_.begin(), params_.end(), [key](const Parameter& param) {
+          return param.key == key;
+        });
+    return it == params_.end() ? nullptr : &*it;
+  }
+
+  const Parameter* getFirstParam(TrackRequestParamKey key) const {
+    return getFirstParam(folly::to_underlying(key));
+  }
+
+  const Parameter* getFirstParam(SetupKey key) const {
+    return getFirstParam(folly::to_underlying(key));
+  }
+
+  bool hasParam(uint64_t key) const {
+    return getFirstParam(key) != nullptr;
+  }
+
   folly::Expected<folly::Unit, ErrorCode> insertParam(Parameter&& param) {
     auto key = static_cast<TrackRequestParamKey>(param.key);
     if (!isParamAllowed(key)) {
@@ -680,7 +702,10 @@ class Parameters {
   }
 
   void eraseAllParamsOfType(TrackRequestParamKey key) {
-    const auto targetKey = static_cast<uint64_t>(key);
+    eraseAllParamsOfType(folly::to_underlying(key));
+  }
+
+  void eraseAllParamsOfType(uint64_t targetKey) {
     params_.erase(
         std::remove_if(
             params_.begin(),
@@ -744,13 +769,15 @@ std::optional<uint64_t> getFirstIntParam(
 inline std::string getFirstStringParam(
     const SetupParameters& params,
     uint64_t key) {
-  for (const auto& param : params) {
-    if (param.key == key) {
-      return param.asString;
-    }
-  }
-  return {};
+  const auto* param = params.getFirstParam(key);
+  return param ? param->asString : std::string();
 }
+
+// Applies extraParams onto params, replacing any parameter with the same key
+// so a SETUP never carries a key twice.
+void applySetupParameters(
+    SetupParameters& params,
+    const std::vector<SetupParameter>& extraParams);
 
 struct Setup {
   SetupParameters params{FrameType::CLIENT_SETUP};

--- a/moxygen/test/MoQFramerTest.cpp
+++ b/moxygen/test/MoQFramerTest.cpp
@@ -5990,6 +5990,127 @@ TEST(MoQFramerV16DeathTest, PublishNamespaceCancelWithoutRequestIDDies) {
       "RequestID required for v16\\+ PublishNamespaceCancel");
 }
 
+// Tests for Parameters::getFirstParam() / hasParam()
+class ParametersLookupTest : public ::testing::Test {};
+
+TEST_F(ParametersLookupTest, GetFirstParamReturnsEarliestMatch) {
+  Parameters params(FrameType::SUBSCRIBE);
+  ASSERT_TRUE(params
+                  .insertParam(Parameter(
+                      folly::to_underlying(
+                          TrackRequestParamKey::DELIVERY_TIMEOUT),
+                      1))
+                  .hasValue());
+  ASSERT_TRUE(params
+                  .insertParam(Parameter(
+                      folly::to_underlying(
+                          TrackRequestParamKey::MAX_CACHE_DURATION),
+                      2))
+                  .hasValue());
+  ASSERT_TRUE(params
+                  .insertParam(Parameter(
+                      folly::to_underlying(
+                          TrackRequestParamKey::DELIVERY_TIMEOUT),
+                      3))
+                  .hasValue());
+
+  const auto* found =
+      params.getFirstParam(TrackRequestParamKey::DELIVERY_TIMEOUT);
+  ASSERT_NE(found, nullptr);
+  EXPECT_EQ(found->asUint64, 1);
+  EXPECT_TRUE(params.hasParam(
+      folly::to_underlying(TrackRequestParamKey::MAX_CACHE_DURATION)));
+}
+
+TEST_F(ParametersLookupTest, GetFirstParamReturnsNullWhenAbsent) {
+  Parameters params(FrameType::SUBSCRIBE);
+  EXPECT_EQ(
+      params.getFirstParam(TrackRequestParamKey::DELIVERY_TIMEOUT), nullptr);
+  EXPECT_FALSE(params.hasParam(
+      folly::to_underlying(TrackRequestParamKey::DELIVERY_TIMEOUT)));
+}
+
+TEST_F(ParametersLookupTest, GetFirstParamAcceptsSetupKeys) {
+  SetupParameters params(FrameType::CLIENT_SETUP);
+  ASSERT_TRUE(params
+                  .insertParam(SetupParameter(
+                      folly::to_underlying(SetupKey::MAX_REQUEST_ID), 17))
+                  .hasValue());
+
+  const auto* found = params.getFirstParam(SetupKey::MAX_REQUEST_ID);
+  ASSERT_NE(found, nullptr);
+  EXPECT_EQ(found->asUint64, 17);
+  EXPECT_EQ(params.getFirstParam(SetupKey::PATH), nullptr);
+}
+
+// Tests for applySetupParameters()
+class ApplySetupParametersTest : public ::testing::Test {};
+
+TEST_F(ApplySetupParametersTest, AppendsUnknownKeys) {
+  SetupParameters params(FrameType::CLIENT_SETUP);
+  ASSERT_TRUE(params
+                  .insertParam(SetupParameter(
+                      folly::to_underlying(SetupKey::MAX_REQUEST_ID), 100))
+                  .hasValue());
+
+  constexpr uint64_t kExtensionKey = 0x40B55;
+  applySetupParameters(
+      params, {SetupParameter(kExtensionKey, std::string{})});
+
+  EXPECT_EQ(params.size(), 2);
+  EXPECT_EQ(params.getFirstParam(SetupKey::MAX_REQUEST_ID)->asUint64, 100);
+  ASSERT_NE(params.getFirstParam(kExtensionKey), nullptr);
+  EXPECT_TRUE(params.getFirstParam(kExtensionKey)->asString.empty());
+}
+
+TEST_F(ApplySetupParametersTest, OverrideReplacesRatherThanDuplicates) {
+  SetupParameters params(FrameType::CLIENT_SETUP);
+  ASSERT_TRUE(params
+                  .insertParam(SetupParameter(
+                      folly::to_underlying(SetupKey::MAX_REQUEST_ID), 100))
+                  .hasValue());
+  ASSERT_TRUE(
+      params
+          .insertParam(SetupParameter(
+              folly::to_underlying(SetupKey::MAX_AUTH_TOKEN_CACHE_SIZE), 16))
+          .hasValue());
+
+  applySetupParameters(
+      params,
+      {SetupParameter(folly::to_underlying(SetupKey::MAX_REQUEST_ID), 500)});
+
+  EXPECT_EQ(params.size(), 2);
+  EXPECT_EQ(params.getFirstParam(SetupKey::MAX_REQUEST_ID)->asUint64, 500);
+  EXPECT_EQ(
+      params.getFirstParam(SetupKey::MAX_AUTH_TOKEN_CACHE_SIZE)->asUint64, 16);
+}
+
+TEST_F(ApplySetupParametersTest, LastWriterWinsAmongExtraParams) {
+  SetupParameters params(FrameType::CLIENT_SETUP);
+  constexpr uint64_t kExtensionKey = 0x40B55;
+
+  applySetupParameters(
+      params,
+      {SetupParameter(kExtensionKey, std::string("first")),
+       SetupParameter(kExtensionKey, std::string("second"))});
+
+  EXPECT_EQ(params.size(), 1);
+  EXPECT_EQ(params.getFirstParam(kExtensionKey)->asString, "second");
+}
+
+TEST_F(ApplySetupParametersTest, EmptyExtraParamsLeavesParamsUntouched) {
+  SetupParameters params(FrameType::CLIENT_SETUP);
+  ASSERT_TRUE(params
+                  .insertParam(SetupParameter(
+                      folly::to_underlying(SetupKey::MAX_REQUEST_ID), 100))
+                  .hasValue());
+
+  applySetupParameters(params, {});
+
+  EXPECT_EQ(params.size(), 1);
+  EXPECT_EQ(params.getFirstParam(SetupKey::MAX_REQUEST_ID)->asUint64, 100);
+}
+
 // Tests for Parameters::isParamAllowed()
 class ParametersIsParamAllowedTest : public ::testing::Test {};
 


### PR DESCRIPTION
An application had no way to put its own parameter on a SETUP, which is how a protocol extension advertises itself. This adds addSetupParameter() to MoQClientBase and MoQServerBase.

Supplied parameters are applied after the built-in ones and replace any parameter with the same key rather than appending a second copy, since a setup key must not appear twice on the wire. That includes MOQT_IMPLEMENTATION, which MoQSession stamps on after the base class has built the Setup. Parameters::getFirstParam()/hasParam() are the general form of the existing getFirstIntParam()/getFirstStringParam() helpers, added here for the duplicate check.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/354)
<!-- Reviewable:end -->
