### PR TITLE
setup: negotiate protocol extensions once, as a bitmask

### DIFF
--- a/moxygen/MoQCodec.h
+++ b/moxygen/MoQCodec.h
@@ -33,9 +33,13 @@ class MoQCodec {
     streamId_ = streamId;
   }
 
-  void initializeVersion(uint64_t version) {
+  void initializeVersion(uint64_t version, SetupExtensions extensions = {}) {
     negotiatedVersion_ = version;
-    moqFrameParser_.initializeVersion(version);
+    moqFrameParser_.initializeVersion(version, extensions);
+  }
+
+  void setNegotiatedExtensions(SetupExtensions extensions) {
+    moqFrameParser_.setNegotiatedExtensions(extensions);
   }
 
   void setMaxAuthTokenCacheSize(size_t size) {

--- a/moxygen/MoQFramer.h
+++ b/moxygen/MoQFramer.h
@@ -307,14 +307,30 @@ class MoQFrameParser {
       size_t& length,
       ObjectHeader& objectHeader) const noexcept;
 
-  void initializeVersion(uint64_t versionIn) {
+  // Framers built after the setup exchange should pass the session's
+  // extensions here; the session's own pair learns its version first and picks
+  // the extensions up later via setNegotiatedExtensions().
+  void initializeVersion(uint64_t versionIn, SetupExtensions extensions = {}) {
     XCHECK(!version_) << "Version already initialized";
     version_ = versionIn;
     useMoQVarint_ = getDraftMajorVersion(versionIn) >= 17;
+    extensions_ = extensions;
   }
 
   std::optional<uint64_t> getVersion() const {
     return version_;
+  }
+
+  void setNegotiatedExtensions(SetupExtensions extensions) noexcept {
+    extensions_ = extensions;
+  }
+
+  SetupExtensions getNegotiatedExtensions() const noexcept {
+    return extensions_;
+  }
+
+  bool hasExtension(SetupExtension extension) const noexcept {
+    return extensions_.has(extension);
   }
 
   // Decode a TRACK_NAMESPACE_PREFIX parameter value (a Track Namespace tuple,
@@ -530,6 +546,7 @@ class MoQFrameParser {
 
   std::optional<uint64_t> version_;
   bool useMoQVarint_{false};
+  SetupExtensions extensions_;
   MoQTokenCache* tokenCache_{nullptr};
   mutable std::optional<uint64_t> previousObjectID_;
   // Context for FETCH object delta encoding (draft-15+)
@@ -752,14 +769,28 @@ class MoQFrameWriter {
       const std::string& tokenValue,
       const std::optional<uint64_t>& forceVersion = std::nullopt) const;
 
-  void initializeVersion(uint64_t versionIn) {
+  // See MoQFrameParser::initializeVersion.
+  void initializeVersion(uint64_t versionIn, SetupExtensions extensions = {}) {
     XCHECK(!version_) << "Version already initialized";
     version_ = versionIn;
     useMoQVarint_ = getDraftMajorVersion(versionIn) >= 17;
+    extensions_ = extensions;
   }
 
   std::optional<uint64_t> getVersion() const {
     return version_;
+  }
+
+  void setNegotiatedExtensions(SetupExtensions extensions) noexcept {
+    extensions_ = extensions;
+  }
+
+  SetupExtensions getNegotiatedExtensions() const noexcept {
+    return extensions_;
+  }
+
+  bool hasExtension(SetupExtension extension) const noexcept {
+    return extensions_.has(extension);
   }
 
   // Encode a TrackNamespace as a TRACK_NAMESPACE_PREFIX parameter (a Track
@@ -924,6 +955,7 @@ class MoQFrameWriter {
 
   std::optional<uint64_t> version_;
   bool useMoQVarint_{false};
+  SetupExtensions extensions_;
   mutable std::optional<uint64_t> previousObjectID_;
   // Context for FETCH object delta encoding (draft-15+)
   mutable std::optional<uint64_t> previousFetchGroup_;

--- a/moxygen/MoQRelaySession.cpp
+++ b/moxygen/MoQRelaySession.cpp
@@ -1538,9 +1538,10 @@ class MoQNamespacePublishHandle : public Publisher::NamespacePublishHandle {
  public:
   MoQNamespacePublishHandle(
       std::shared_ptr<SubNSReply> subNsReply,
-      uint64_t negotiatedVersion)
+      uint64_t negotiatedVersion,
+      SetupExtensions extensions)
       : subNsReply_(std::move(subNsReply)) {
-    moqFrameWriter_.initializeVersion(negotiatedVersion);
+    moqFrameWriter_.initializeVersion(negotiatedVersion, extensions);
   }
 
   void namespaceMsg(const TrackNamespace& trackNamespaceSuffix) override {
@@ -1577,7 +1578,7 @@ folly::coro::Task<void> MoQRelaySession::handleSubscribeNamespace(
   std::shared_ptr<MoQNamespacePublishHandle> publishHandle;
   if (getDraftMajorVersion(*negotiatedVersion_) >= 16) {
     publishHandle = std::make_shared<MoQNamespacePublishHandle>(
-        subNsReply, *negotiatedVersion_);
+        subNsReply, *negotiatedVersion_, getNegotiatedExtensions());
   }
   auto subAnnResult = co_await co_awaitTry(co_withCancellation(
       cancellationSource_.getToken(),

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -532,7 +532,8 @@ StreamPublisherImpl::StreamPublisherImpl(
     }
   }
 
-  moqFrameWriter_.initializeVersion(publisher->getVersion());
+  moqFrameWriter_.initializeVersion(
+      publisher->getVersion(), publisher->getNegotiatedExtensions());
   moqFrameWriter_.setFetchGroupOrder(publisher->getGroupOrder());
   (void)moqFrameWriter_.writeFetchHeader(writeBuf_, publisher->requestID());
 }
@@ -2714,6 +2715,8 @@ folly::Expected<folly::Unit, quic::TransportErrorCode> MoQSession::sendSetup(
          getMoQTImplementationString()}));
   }
 
+  onSetupParams(setup.params, /*local=*/true);
+
   uint64_t setupSerializationVersion = kVersionDraft14;
   if (negotiatedVersion_) {
     setupSerializationVersion = *negotiatedVersion_;
@@ -2834,6 +2837,8 @@ void MoQSession::onServerSetup(Setup serverSetup) {
     initializeNegotiatedVersion(kVersionDraft14);
   }
 
+  onSetupParams(serverSetup.params, /*local=*/false);
+
   initPeerMaxRequestID(serverSetup.params);
   auto peerAuthCacheSize = getMaxAuthTokenCacheSizeIfPresent(
       serverSetup.params, *getNegotiatedVersion());
@@ -2908,6 +2913,11 @@ void MoQSession::onClientSetup(Setup clientSetup) {
     initializeNegotiatedVersion(kVersionDraft14);
   }
 
+  // After the version is settled: in uni control mode the server has already
+  // sent SERVER_SETUP, making this the second half, and extension rules are
+  // version-dependent.
+  onSetupParams(clientSetup.params, /*local=*/false);
+
   // Validate authority with the negotiated version
   auto authorityValidation = serverSetupCallback_->validateAuthority(
       clientSetup, *getNegotiatedVersion(), shared_from_this());
@@ -2954,7 +2964,7 @@ std::unique_ptr<MoQControlCodec> MoQSession::makeBidiCodec(
     std::deque<RequestID>* responseIDQueue) {
   auto codec = std::make_unique<MoQBidiStreamCodec>(
       callback, std::move(allowedFrames), requestID, okType);
-  codec->initializeVersion(*negotiatedVersion_);
+  codec->initializeVersion(*negotiatedVersion_, negotiatedExtensions_);
   codec->setTokenCache(&receiveTokenCache_);
   codec->setResponseIDQueue(responseIDQueue);
   return codec;
@@ -3763,7 +3773,7 @@ folly::coro::Task<void> MoQSession::dataStreamReadLoop(
   }
 
   MoQObjectStreamCodec codec(nullptr);
-  codec.initializeVersion(*negotiatedVersion_);
+  codec.initializeVersion(*negotiatedVersion_, negotiatedExtensions_);
 
   // Baton for waiting on unknown alias
   TimedBaton aliasBaton;
@@ -6654,7 +6664,7 @@ void MoQSession::onDatagram(std::unique_ptr<folly::IOBuf> datagram) noexcept {
   size_t remainingLength = readBuf.chainLength();
   folly::io::Cursor cursor(readBuf.front());
   MoQFrameParser parser;
-  parser.initializeVersion(*negotiatedVersion_);
+  parser.initializeVersion(*negotiatedVersion_, negotiatedExtensions_);
   auto type = parser.decodeVarint(cursor);
   if (!type) {
     XLOG(ERR) << __func__ << " Bad datagram header failed to parse type l="
@@ -6829,6 +6839,44 @@ void MoQSession::initializeNegotiatedVersion(uint64_t negotiatedVersion) {
   if (logger_) {
     logger_->setNegotiatedMoQVersion(negotiatedVersion);
   }
+}
+
+/*static*/
+const std::vector<SetupExtensionDescriptor>& MoQSession::kSetupExtensions() {
+  static const std::vector<SetupExtensionDescriptor> kExtensions{};
+  return kExtensions;
+}
+
+/*static*/
+SetupExtensions MoQSession::computeNegotiatedExtensions(
+    const SetupParameters& localParams,
+    const SetupParameters& peerParams,
+    uint64_t version,
+    const std::vector<SetupExtensionDescriptor>& descriptors) {
+  SetupExtensions extensions;
+  for (const auto& descriptor : descriptors) {
+    if (descriptor.negotiate(localParams, peerParams, version)) {
+      extensions.add(descriptor.extension);
+    }
+  }
+  return extensions;
+}
+
+void MoQSession::onSetupParams(SetupParameters params, bool local) {
+  auto& half = local ? localSetupParams_ : peerSetupParams_;
+  XCHECK(!half) << "Setup already recorded local=" << local << " sess=" << this;
+  half = std::move(params);
+  if (!localSetupParams_ || !peerSetupParams_) {
+    return;
+  }
+
+  // Rules may be version-dependent, so both callers record their half only
+  // after the version is settled.
+  XCHECK(negotiatedVersion_) << "Setup complete without a version sess=" << this;
+  negotiatedExtensions_ = computeNegotiatedExtensions(
+      *localSetupParams_, *peerSetupParams_, *negotiatedVersion_);
+  moqFrameWriter_.setNegotiatedExtensions(negotiatedExtensions_);
+  controlCodec_->setNegotiatedExtensions(negotiatedExtensions_);
 }
 
 /*static*/

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -234,6 +234,43 @@ class MoQSession : public Subscriber,
     return negotiatedVersion_;
   }
 
+  // Every extension this build knows how to negotiate, and the rule that wins
+  // each one. Empty until the first extension lands; adding one is a bit in
+  // SetupExtension plus a row here.
+  static const std::vector<SetupExtensionDescriptor>& kSetupExtensions();
+
+  // Runs each rule in `descriptors` over the two SETUPs. `descriptors` is a
+  // parameter so tests can negotiate extensions this build doesn't ship.
+  static SetupExtensions computeNegotiatedExtensions(
+      const SetupParameters& localParams,
+      const SetupParameters& peerParams,
+      uint64_t version,
+      const std::vector<SetupExtensionDescriptor>& descriptors =
+          kSetupExtensions());
+
+  // Whether `extension` is in force here. False until both SETUPs are known.
+  virtual bool negotiatedSetupExtension(SetupExtension extension) const
+      noexcept {
+    return negotiatedExtensions_.has(extension);
+  }
+
+  // For framers built after the setup exchange; see
+  // MoQFrameParser::initializeVersion.
+  SetupExtensions getNegotiatedExtensions() const noexcept {
+    return negotiatedExtensions_;
+  }
+
+  // The SETUP this endpoint sent / the peer sent, retained for extensions that
+  // negotiate on something other than mutual advertisement. Empty until sent /
+  // received respectively.
+  const std::optional<SetupParameters>& getLocalSetupParams() const {
+    return localSetupParams_;
+  }
+
+  const std::optional<SetupParameters>& getPeerSetupParams() const {
+    return peerSetupParams_;
+  }
+
   virtual std::shared_ptr<SubNSReply> getSubNsReply(
       std::shared_ptr<ReplyContext> replyContext) {
     return std::make_shared<SubNSReply>(
@@ -373,7 +410,9 @@ class MoQSession : public Subscriber,
           groupOrder_(groupOrder),
           version_(version),
           bytesBufferedThreshold_(bytesBufferedThreshold) {
-      moqFrameWriter_.initializeVersion(version);
+      moqFrameWriter_.initializeVersion(
+          version,
+          session_ ? session_->getNegotiatedExtensions() : SetupExtensions());
     }
 
     virtual ~PublisherImpl() = default;
@@ -448,6 +487,10 @@ class MoQSession : public Subscriber,
 
     uint64_t getVersion() const {
       return version_;
+    }
+
+    SetupExtensions getNegotiatedExtensions() const {
+      return moqFrameWriter_.getNegotiatedExtensions();
     }
 
     void onBytesBuffered(uint64_t amount) {
@@ -1228,6 +1271,11 @@ class MoQSession : public Subscriber,
 
   // Private implementation methods
   void initializeNegotiatedVersion(uint64_t negotiatedVersion);
+  // Records one half of the setup exchange. Once both halves are in, computes
+  // the negotiated extensions and pushes them to the framers, which is why
+  // this runs before any frame that an extension could alter is sent or
+  // parsed.
+  void onSetupParams(SetupParameters params, bool local);
   void removeBufferedSubgroupBaton(TrackAlias alias, TimedBaton* baton);
   void scheduleGoawayTimeout(uint64_t timeoutMs);
   void cancelGoawayTimeout();
@@ -1236,6 +1284,9 @@ class MoQSession : public Subscriber,
   bool hasOpenRequestsForGoaway() const;
 
   // Private session state
+  std::optional<SetupParameters> localSetupParams_;
+  std::optional<SetupParameters> peerSetupParams_;
+  SetupExtensions negotiatedExtensions_;
   folly::F14FastMap<RequestID, std::shared_ptr<PublisherImpl>, RequestID::hash>
       pubTracks_;
   folly::F14FastSet<FullTrackName, FullTrackName::hash> pendingPublishTracks_;

--- a/moxygen/MoQTypes.cpp
+++ b/moxygen/MoQTypes.cpp
@@ -470,6 +470,15 @@ Fetch::Fetch(
   }
 }
 
+SetupExtensionNegotiator bothAdvertise(uint64_t key) {
+  return [key](
+             const SetupParameters& local,
+             const SetupParameters& peer,
+             uint64_t /*version*/) {
+    return local.hasParam(key) && peer.hasParam(key);
+  };
+}
+
 void applySetupParameters(
     SetupParameters& params,
     const std::vector<SetupParameter>& extraParams) {

--- a/moxygen/MoQTypes.h
+++ b/moxygen/MoQTypes.h
@@ -13,6 +13,7 @@
 #include <proxygen/lib/http/webtransport/WebTransport.h>
 #include <algorithm>
 #include <limits>
+#include <functional>
 #include <optional>
 #include <vector>
 
@@ -778,6 +779,56 @@ inline std::string getFirstStringParam(
 void applySetupParameters(
     SetupParameters& params,
     const std::vector<SetupParameter>& extraParams);
+
+// A protocol extension that is off unless the two SETUPs negotiate it on. Each
+// extension owns one bit; MoQSession::kSetupExtensions says how a bit is won.
+enum class SetupExtension : uint32_t {
+  None = 0,
+  // Extensions add a bit here, e.g. Foo = 1u << 0.
+};
+
+// The set of extensions in force on a session.
+class SetupExtensions {
+ public:
+  SetupExtensions() = default;
+
+  bool has(SetupExtension extension) const {
+    auto bit = folly::to_underlying(extension);
+    return bit != 0 && (bits_ & bit) == bit;
+  }
+
+  void add(SetupExtension extension) {
+    bits_ |= folly::to_underlying(extension);
+  }
+
+  bool empty() const {
+    return bits_ == 0;
+  }
+
+  bool operator==(const SetupExtensions& other) const {
+    return bits_ == other.bits_;
+  }
+
+ private:
+  uint32_t bits_{0};
+};
+
+// Decides whether one extension is on, given both SETUPs and the negotiated
+// draft. Free to look at values rather than presence, to apply an asymmetric
+// rule, and to turn itself off on drafts it doesn't apply to.
+using SetupExtensionNegotiator = std::function<bool(
+    const SetupParameters& local,
+    const SetupParameters& peer,
+    uint64_t version)>;
+
+// Ties an extension bit to the rule that wins it.
+struct SetupExtensionDescriptor {
+  SetupExtension extension;
+  SetupExtensionNegotiator negotiate;
+};
+
+// Negotiator for the simplest rule: both peers carry `key`, whatever its value.
+SetupExtensionNegotiator bothAdvertise(uint64_t key);
 
 struct Setup {
   SetupParameters params{FrameType::CLIENT_SETUP};

--- a/moxygen/test/MoQSessionTests.cpp
+++ b/moxygen/test/MoQSessionTests.cpp
@@ -46,6 +46,166 @@ TEST_P(MoQVersionNegotiationTest, Setup) {
   folly::coro::blockingWait(setupMoQSession(), getExecutor());
   clientSession_->close(SessionCloseErrorCode::NO_ERROR);
 }
+
+// Tests for MoQSession::computeNegotiatedExtensions(). The shipped table is
+// empty, so these inject their own descriptors.
+class SetupExtensionsTest : public ::testing::Test {
+ protected:
+  static constexpr auto kExtA = static_cast<SetupExtension>(1u << 0);
+  static constexpr auto kExtB = static_cast<SetupExtension>(1u << 1);
+  static constexpr uint64_t kKeyA = 0x40B55;
+  static constexpr uint64_t kKeyB = 0x40B56;
+  static constexpr uint64_t kVersion = kVersionDraft18;
+
+  const std::vector<SetupExtensionDescriptor> mutualFlags_{
+      {kExtA, bothAdvertise(kKeyA)},
+      {kExtB, bothAdvertise(kKeyB)}};
+
+  static SetupParameters params(std::vector<SetupParameter> setupParams) {
+    SetupParameters result(FrameType::CLIENT_SETUP);
+    for (auto& param : setupParams) {
+      result.insertParam(std::move(param));
+    }
+    return result;
+  }
+
+  static SetupParameter flag(uint64_t key) {
+    return SetupParameter(key, std::string{});
+  }
+};
+
+TEST_F(SetupExtensionsTest, MutualFlagNegotiatesWhenBothAdvertise) {
+  auto extensions = MoQSession::computeNegotiatedExtensions(
+      params({flag(kKeyA)}), params({flag(kKeyA)}), kVersion, mutualFlags_);
+  EXPECT_TRUE(extensions.has(kExtA));
+  EXPECT_FALSE(extensions.has(kExtB));
+}
+
+TEST_F(SetupExtensionsTest, MutualFlagNeedsBothSides) {
+  EXPECT_TRUE(MoQSession::computeNegotiatedExtensions(
+                  params({flag(kKeyA)}), params({}), kVersion, mutualFlags_)
+                  .empty());
+  EXPECT_TRUE(MoQSession::computeNegotiatedExtensions(
+                  params({}), params({flag(kKeyA)}), kVersion, mutualFlags_)
+                  .empty());
+  EXPECT_TRUE(MoQSession::computeNegotiatedExtensions(
+                  params({}), params({}), kVersion, mutualFlags_)
+                  .empty());
+}
+
+TEST_F(SetupExtensionsTest, ExtensionsAreIndependent) {
+  auto extensions = MoQSession::computeNegotiatedExtensions(
+      params({flag(kKeyA), flag(kKeyB)}),
+      params({flag(kKeyB)}),
+      kVersion,
+      mutualFlags_);
+  EXPECT_FALSE(extensions.has(kExtA));
+  EXPECT_TRUE(extensions.has(kExtB));
+  EXPECT_FALSE(extensions.empty());
+}
+
+TEST_F(SetupExtensionsTest, UnrelatedSetupParamsDoNotNegotiate) {
+  auto maxRequestID = params(
+      {SetupParameter(folly::to_underlying(SetupKey::MAX_REQUEST_ID), 8)});
+  EXPECT_TRUE(MoQSession::computeNegotiatedExtensions(
+                  maxRequestID, maxRequestID, kVersion, mutualFlags_)
+                  .empty());
+}
+
+// A rule can inspect values, be asymmetric, and depend on the draft -- the
+// point of taking a negotiator rather than a key.
+TEST_F(SetupExtensionsTest, RuleCanNegotiateOnValue) {
+  const std::vector<SetupExtensionDescriptor> byValue{
+      {kExtA,
+       [](const SetupParameters& local,
+          const SetupParameters& peer,
+          uint64_t) {
+         const auto* localParam = local.getFirstParam(kKeyA);
+         const auto* peerParam = peer.getFirstParam(kKeyA);
+         return localParam && peerParam &&
+             std::min(localParam->asUint64, peerParam->asUint64) > 0;
+       }}};
+
+  EXPECT_TRUE(MoQSession::computeNegotiatedExtensions(
+                  params({SetupParameter(kKeyA, 4)}),
+                  params({SetupParameter(kKeyA, 2)}),
+                  kVersion,
+                  byValue)
+                  .has(kExtA));
+  EXPECT_FALSE(MoQSession::computeNegotiatedExtensions(
+                   params({SetupParameter(kKeyA, 4)}),
+                   params({SetupParameter(kKeyA, 0)}),
+                   kVersion,
+                   byValue)
+                   .has(kExtA));
+}
+
+// Modelled on the auth token cache: my advertisement governs what I receive,
+// the peer's governs what I send, so the two directions can differ.
+TEST_F(SetupExtensionsTest, RuleCanBeAsymmetric) {
+  const std::vector<SetupExtensionDescriptor> perDirection{
+      {kExtA,
+       [](const SetupParameters& local, const SetupParameters&, uint64_t) {
+         return local.hasParam(kKeyA);
+       }},
+      {kExtB,
+       [](const SetupParameters&, const SetupParameters& peer, uint64_t) {
+         return peer.hasParam(kKeyA);
+       }}};
+
+  auto extensions = MoQSession::computeNegotiatedExtensions(
+      params({flag(kKeyA)}), params({}), kVersion, perDirection);
+  EXPECT_TRUE(extensions.has(kExtA));
+  EXPECT_FALSE(extensions.has(kExtB));
+}
+
+TEST_F(SetupExtensionsTest, RuleCanDependOnVersion) {
+  const std::vector<SetupExtensionDescriptor> v18Only{
+      {kExtA,
+       [](const SetupParameters& local,
+          const SetupParameters& peer,
+          uint64_t version) {
+         return getDraftMajorVersion(version) >= 18 && local.hasParam(kKeyA) &&
+             peer.hasParam(kKeyA);
+       }}};
+
+  auto both = params({flag(kKeyA)});
+  EXPECT_TRUE(MoQSession::computeNegotiatedExtensions(
+                  both, both, kVersionDraft18, v18Only)
+                  .has(kExtA));
+  EXPECT_FALSE(MoQSession::computeNegotiatedExtensions(
+                   both, both, kVersionDraft17, v18Only)
+                   .has(kExtA));
+}
+
+TEST_F(SetupExtensionsTest, NoneIsNeverHeld) {
+  auto extensions = MoQSession::computeNegotiatedExtensions(
+      params({flag(kKeyA)}), params({flag(kKeyA)}), kVersion, mutualFlags_);
+  EXPECT_FALSE(extensions.has(SetupExtension::None));
+  EXPECT_FALSE(SetupExtensions().has(SetupExtension::None));
+}
+
+TEST_F(SetupExtensionsTest, ShippedTableNegotiatesNothingYet) {
+  EXPECT_TRUE(MoQSession::kSetupExtensions().empty());
+  EXPECT_TRUE(MoQSession::computeNegotiatedExtensions(
+                  params({flag(kKeyA)}), params({flag(kKeyA)}), kVersion)
+                  .empty());
+}
+
+// Both halves of the setup exchange are retained on both endpoints, which is
+// what extension negotiation runs on.
+TEST_P(MoQVersionNegotiationTest, SetupParamsRetainedOnBothEndpoints) {
+  folly::coro::blockingWait(setupMoQSession(), getExecutor());
+  for (auto* session : {clientSession_.get(), serverSession_.get()}) {
+    ASSERT_TRUE(session->getLocalSetupParams().has_value());
+    ASSERT_TRUE(session->getPeerSetupParams().has_value());
+    EXPECT_TRUE(session->getLocalSetupParams()->hasParam(
+        folly::to_underlying(SetupKey::MAX_REQUEST_ID)));
+    EXPECT_TRUE(session->getPeerSetupParams()->hasParam(
+        folly::to_underlying(SetupKey::MAX_REQUEST_ID)));
+  }
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+}
 using CurrentVersionOnly = MoQSessionTest;
 
 CO_TEST_P_X(CurrentVersionOnly, SetupTimeout) {

--- a/moxygen/test/MockMoQSession.h
+++ b/moxygen/test/MockMoQSession.h
@@ -75,6 +75,12 @@ class MockMoQSession : public MoQSession {
       (const, override));
 
   MOCK_METHOD(
+      bool,
+      negotiatedSetupExtension,
+      (SetupExtension),
+      (const, noexcept, override));
+
+  MOCK_METHOD(
       folly::coro::Task<Publisher::TrackStatusResult>,
       trackStatus,
       (TrackStatus),


### PR DESCRIPTION
Extensions need to know whether both peers agreed to them, but the session threw away the SETUP params after pulling out the few values it wanted, so there was nothing left to compare. Without a shared mechanism each extension ends up adding its own bool to MoQSession plus a setter on every codec and framer.

MoQSession now keeps both halves of the setup exchange and computes a SetupExtensions bitmask once, when the second half arrives, pushing it to the framers before any frame an extension could change is sent or parsed. Extensions are declared in one table, kSetupExtensions, which ships empty; the first extension adds a bit and a row.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/355)
<!-- Reviewable:end -->
