### PR TITLE
standalone: publish sanitizer-instrumented artifact flavors (asan, tsan)

### DIFF
--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -155,6 +155,14 @@ jobs:
             sanitizer: asan
             build_type: Debug
 
+          - name: ubuntu-24.04-amd64-tsan
+            runner: ubuntu-24.04
+            artifact: moxygen-ubuntu-24.04-amd64-tsan.tar.gz
+            debug_artifact: moxygen-ubuntu-24.04-amd64-tsan-dbg.tar.gz
+            container: ""
+            sanitizer: tsan
+            build_type: Debug
+
           - name: macos-15-arm64
             runner: macos-15
             artifact: moxygen-macos-15-arm64.tar.gz

--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -146,6 +146,15 @@ jobs:
             debug_artifact: moxygen-ubuntu-24.04-amd64-dbg.tar.gz
             container: ""
 
+          # Sanitizer flavors: Debug is ABI (folly kIsDebug); consumers must match.
+          - name: ubuntu-24.04-amd64-asan
+            runner: ubuntu-24.04
+            artifact: moxygen-ubuntu-24.04-amd64-asan.tar.gz
+            debug_artifact: moxygen-ubuntu-24.04-amd64-asan-dbg.tar.gz
+            container: ""
+            sanitizer: asan
+            build_type: Debug
+
           - name: macos-15-arm64
             runner: macos-15
             artifact: moxygen-macos-15-arm64.tar.gz
@@ -214,10 +223,13 @@ jobs:
             # Self-hosted without container: use home dir
             EXTRA_FLAGS+=(-DFETCHCONTENT_BASE_DIR="$HOME/.cache/moxygen-publish-${{ matrix.name }}/_deps")
           fi
+          if [ -n "${{ matrix.sanitizer }}" ]; then
+            EXTRA_FLAGS+=(-DMOXYGEN_SANITIZER="${{ matrix.sanitizer }}")
+          fi
           cmake -B _build -S standalone -G Ninja \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type || 'RelWithDebInfo' }} \
             -DBUILD_TESTING=OFF \
             -DBUILD_SHARED_LIBS=OFF \
             -DBUNDLE_DEPS=ON \

--- a/openmoq/scripts/publish-artifacts.sh
+++ b/openmoq/scripts/publish-artifacts.sh
@@ -132,6 +132,8 @@ else
   git push origin ":refs/tags/$TAG" 2>/dev/null || true
 
   # Create as pre-release so it doesn't show as "Latest release"
+  # --target must stay an explicit sha: downstream fetchers verify
+  # target_commitish; gh defaults to a branch name for existing tags.
   # shellcheck disable=SC2086
   gh release create "$TAG" \
     --target "$SHA" \

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -52,6 +52,32 @@ option(BUILD_PICOQUIC "Build with picoquic transport support" ON)
 option(BUNDLE_DEPS_STATIC_SYSLIBS
     "Static-link glog/gflags/double-conversion in BUNDLE_DEPS artifact" OFF)
 
+# Consumers of the resulting archives must build with the same -fsanitize= flags.
+set(MOXYGEN_SANITIZER "" CACHE STRING
+    "Sanitizer flavor(s) for all layers: asan, tsan, ubsan; combine with +")
+if(MOXYGEN_SANITIZER)
+    string(REPLACE "+" ";" _san_tokens "${MOXYGEN_SANITIZER}")
+    set(_san_flags "")
+    foreach(_san IN LISTS _san_tokens)
+        if(_san STREQUAL "asan")
+            list(APPEND _san_flags -fsanitize=address)
+        elseif(_san STREQUAL "tsan")
+            list(APPEND _san_flags -fsanitize=thread)
+        elseif(_san STREQUAL "ubsan")
+            list(APPEND _san_flags -fsanitize=undefined)
+        else()
+            message(FATAL_ERROR
+                "MOXYGEN_SANITIZER: unknown token '${_san}' "
+                "(expected asan, tsan, or ubsan)")
+        endif()
+    endforeach()
+    if("asan" IN_LIST _san_tokens AND "tsan" IN_LIST _san_tokens)
+        message(FATAL_ERROR "MOXYGEN_SANITIZER: asan and tsan cannot be combined")
+    endif()
+    add_compile_options(${_san_flags} -fno-omit-frame-pointer)
+    add_link_options(${_san_flags})
+endif()
+
 # =============================================================================
 # Linking preferences
 # =============================================================================


### PR DESCRIPTION
Closes #353.

Publishes sanitizer-instrumented variants of the standalone artifacts on every main push, giving consumers full-stack sanitizer coverage (folly through moxygen) at prebuilt-fetch speed instead of a ~30+ min from-source build.

New assets per main push:

- `moxygen-ubuntu-24.04-amd64-asan.tar.gz` + `-dbg` sidecar
- `moxygen-ubuntu-24.04-amd64-tsan.tar.gz` + `-dbg` sidecar

Same layout as the regular artifacts (usable as `CMAKE_PREFIX_PATH`). Separate tarballs because ASan and TSan cannot share a binary.

## Changes

- **`standalone/CMakeLists.txt`** — `MOXYGEN_SANITIZER` cache var, applied globally before any dep is declared so every layer is instrumented.
- **`omoq-ci-main.yml`** — two publish matrix lanes on GH-hosted `ubuntu-24.04`. Configure honors per-entry `build_type`/`sanitizer`; existing lanes unchanged.
- **`publish-artifacts.sh`** — comment pinning the explicit-sha `--target` requirement downstream fetchers verify.

## Notes

- Flavors build `Debug`: folly's `kIsDebug` is ABI, so consumers compile to match.
- Lanes run in parallel with the existing five — ~0–10 min main wall-clock impact (first uncached runs slower while caches warm).
- Tagged releases pick the new assets up automatically via snapshot promotion; no version-release changes.
- Validated locally end-to-end: the asan lane replica produced the tarball with instrumentation verified in every layer's archives, and moqx's sanitizer preset configured, built, and linked cleanly against it.
- Local artifact sizes: 429 MB tarball, 1.7 GB `-dbg` sidecar (Debug + sanitizer debug info) — the sidecar is within GitHub's 2 GB asset limit but worth watching.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/361)
<!-- Reviewable:end -->
