### PR TITLE
standalone: bound apt fetches with timeouts and retries

### DIFF
--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -194,8 +194,9 @@ jobs:
       - name: Install container base deps
         if: matrix.container != ''
         run: |
-          apt-get update
-          apt-get install -y --no-install-recommends \
+          apt_get() { apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 "$@"; }
+          apt_get update
+          apt_get install -y --no-install-recommends \
             git ca-certificates curl pkg-config sudo bash ccache
 
       - name: Install system dependencies

--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -194,7 +194,7 @@ jobs:
       - name: Install container base deps
         if: matrix.container != ''
         run: |
-          apt_get() { apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 "$@"; }
+          apt_get() { timeout -k 30 600 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 "$@"; }
           apt_get update
           apt_get install -y --no-install-recommends \
             git ca-certificates curl pkg-config sudo bash ccache

--- a/standalone/install-system-deps.sh
+++ b/standalone/install-system-deps.sh
@@ -7,11 +7,38 @@
 
 set -e
 
-# apt has no overall deadline: a stalled mirror connection can hang a fetch
-# indefinitely. Bound each transfer and retry so a bad mirror fails the run in
-# minutes instead of wedging it.
+# apt can hang past its own transfer timeouts: a dribbling mirror defeats the
+# 30s read timeout, and a wedged https helper never fires it (the helper is
+# what enforces it). Progress watchdog: healthy apt prints continuously, so
+# kill the call after 2 minutes of output silence; hard-cap the whole call at
+# 15 minutes as a backstop against a mirror that trickles forever.
 apt_get() {
-    sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 "$@"
+    local log pid rc size prev=-1 idle=0
+    log=$(mktemp)
+    sudo timeout -k 30 900 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 "$@" >"$log" 2>&1 &
+    pid=$!
+    tail -f --pid="$pid" "$log" &
+    while kill -0 "$pid" 2>/dev/null; do
+        sleep 5
+        size=$(stat -c %s "$log" 2>/dev/null || echo -1)
+        if [ "$size" = "$prev" ]; then
+            idle=$((idle + 5))
+            if [ "$idle" -ge 120 ]; then
+                echo "ERROR: apt-get made no progress for ${idle}s; aborting" >&2
+                sudo kill "$pid" 2>/dev/null || true
+                sleep 5
+                sudo kill -9 "$pid" 2>/dev/null || true
+                wait "$pid" 2>/dev/null || true
+                rm -f "$log"
+                return 124
+            fi
+        else
+            prev=$size; idle=0
+        fi
+    done
+    wait "$pid" && rc=0 || rc=$?
+    rm -f "$log"
+    return "$rc"
 }
 
 install_ubuntu() {

--- a/standalone/install-system-deps.sh
+++ b/standalone/install-system-deps.sh
@@ -7,10 +7,17 @@
 
 set -e
 
+# apt has no overall deadline: a stalled mirror connection can hang a fetch
+# indefinitely. Bound each transfer and retry so a bad mirror fails the run in
+# minutes instead of wedging it.
+apt_get() {
+    sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 "$@"
+}
+
 install_ubuntu() {
     echo "Installing dependencies for Ubuntu/Debian..."
-    sudo apt-get update
-    sudo apt-get install -y \
+    apt_get update
+    apt_get install -y \
         build-essential \
         cmake \
         ninja-build \


### PR DESCRIPTION
## Why

Same hardening as openmoq/moqx#608. During today's `azure.archive.ubuntu.com` outage (~15:30 UTC), hosted jobs froze mid `apt-get update` for 90+ minutes — apt has no overall fetch deadline, and the hung jobs pinned runner slots against the account's 20-job concurrency cap, queueing everything else.

## What

Add `Acquire::Retries=3` and 30s http/https transfer timeouts to both apt sites:

- `standalone/install-system-deps.sh` — routed the update/install calls through an `apt_get` wrapper (exercised by PR CI on the ubuntu lanes)
- `.github/workflows/omoq-ci-main.yml` — same options on the container base-deps step (main-push only, so not exercised by PR CI; the exact invocation was validated locally in a `debian:bookworm` container)

A wedged mirror now fails the run in a couple of minutes instead of hanging it. Hardening, not a root-cause fix — the outage was upstream infrastructure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/370)
<!-- Reviewable:end -->
