### PR TITLE
publish: retain a pinned per-rev snapshot alongside the rolling alias

### DIFF
--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -4,8 +4,9 @@ name: ci main
 # BUNDLE_DEPS artifacts, release snapshot, notify. PRs use omoq-ci-pr.yml
 # (build/test only).
 #
-# main           → snapshot-latest pre-release
-# release/<lbl>  → snapshot-<lbl>-latest pre-release (independent namespace)
+# Every push  → snapshot-<sha12> pinned pre-release (retained; pin consumers)
+# main           → snapshot-latest rolling alias
+# release/<lbl>  → snapshot-<lbl>-latest rolling alias (independent namespace)
 #
 # Job graph:
 #
@@ -297,7 +298,7 @@ jobs:
         with:
           path: artifacts/
 
-      - name: Compute release tag
+      - name: Compute release tags
         id: tag
         run: |
           BRANCH="${{ github.ref_name }}"
@@ -308,10 +309,26 @@ jobs:
             LABEL="${BRANCH#release/}"
             TAG="snapshot-${LABEL}-latest"
           fi
+          # 12 hex chars matches the moqx prebuilt cache key (_rev_short).
+          PIN_TAG="snapshot-$(echo "$GITHUB_SHA" | cut -c1-12)"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "Release tag: $TAG (branch: $BRANCH)"
+          echo "pin_tag=$PIN_TAG" >> "$GITHUB_OUTPUT"
+          echo "Release tags: $PIN_TAG + $TAG (branch: $BRANCH)"
 
-      - name: Publish snapshot
+      # The pinned per-rev snapshot is the contract pin-following consumers
+      # depend on, so it publishes before the rolling alias: if the alias
+      # upload fails, the rev is still fetchable by pin.
+      - name: Publish pinned snapshot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bash openmoq/scripts/publish-artifacts.sh \
+            --artifacts-dir artifacts/ \
+            --sha "$GITHUB_SHA" \
+            --tag "${{ steps.tag.outputs.pin_tag }}" \
+            --branch "${{ github.ref_name }}"
+
+      - name: Publish rolling snapshot alias
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -4,9 +4,9 @@ name: ci main
 # BUNDLE_DEPS artifacts, release snapshot, notify. PRs use omoq-ci-pr.yml
 # (build/test only).
 #
-# Every push  → snapshot-<sha12> pinned pre-release (retained; pin consumers)
-# main           → snapshot-latest rolling alias
-# release/<lbl>  → snapshot-<lbl>-latest rolling alias (independent namespace)
+# Every push  → snapshot-<sha12> pinned pre-release (assets; 30-day retention)
+# main           → snapshot-latest asset-less pointer to the pinned release
+# release/<lbl>  → snapshot-<lbl>-latest pointer (independent namespace)
 #
 # Job graph:
 #
@@ -315,9 +315,10 @@ jobs:
           echo "pin_tag=$PIN_TAG" >> "$GITHUB_OUTPUT"
           echo "Release tags: $PIN_TAG + $TAG (branch: $BRANCH)"
 
-      # The pinned per-rev snapshot is the contract pin-following consumers
-      # depend on, so it publishes before the rolling alias: if the alias
-      # upload fails, the rev is still fetchable by pin.
+      # The pinned per-rev snapshot carries the assets (uploaded once) and is
+      # the contract pin-following consumers depend on, so it publishes before
+      # the alias: if the alias update fails, the rev is still fetchable by pin.
+      # Pinned snapshots older than 30 days are pruned with their tags.
       - name: Publish pinned snapshot
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -326,14 +327,15 @@ jobs:
             --artifacts-dir artifacts/ \
             --sha "$GITHUB_SHA" \
             --tag "${{ steps.tag.outputs.pin_tag }}" \
-            --branch "${{ github.ref_name }}"
+            --branch "${{ github.ref_name }}" \
+            --prune-days 30
 
-      - name: Publish rolling snapshot alias
+      - name: Publish rolling alias (asset-less pointer)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash openmoq/scripts/publish-artifacts.sh \
-            --artifacts-dir artifacts/ \
+            --pointer-to "${{ steps.tag.outputs.pin_tag }}" \
             --sha "$GITHUB_SHA" \
             --tag "${{ steps.tag.outputs.tag }}" \
             --branch "${{ github.ref_name }}"

--- a/.github/workflows/omoq-version-release.yml
+++ b/.github/workflows/omoq-version-release.yml
@@ -58,6 +58,7 @@ jobs:
       tag: ${{ steps.v.outputs.tag }}
       snapshot_tag: ${{ steps.v.outputs.snapshot_tag }}
       snapshot_sha: ${{ steps.v.outputs.snapshot_sha }}
+      promote_tag: ${{ steps.v.outputs.promote_tag }}
     steps:
       - uses: actions/checkout@v4
 
@@ -94,13 +95,25 @@ jobs:
             exit 1
           fi
 
+          # Assets live on the pinned per-rev release; the alias is an
+          # asset-less pointer. Fall back to the alias for snapshots published
+          # before pinned releases existed (it still carries assets there).
+          PIN_TAG="snapshot-${SNAPSHOT_SHA:0:12}"
+          if gh api "repos/{owner}/{repo}/releases/tags/$PIN_TAG" --jq .id >/dev/null 2>&1; then
+            PROMOTE_TAG="$PIN_TAG"
+          else
+            echo "Note: $PIN_TAG not found — promoting from $SNAPSHOT_TAG (pre-pinned-snapshot build)"
+            PROMOTE_TAG="$SNAPSHOT_TAG"
+          fi
+
           {
             echo "version=$VERSION"
             echo "tag=$TAG"
             echo "snapshot_tag=$SNAPSHOT_TAG"
             echo "snapshot_sha=$SNAPSHOT_SHA"
+            echo "promote_tag=$PROMOTE_TAG"
           } >> "$GITHUB_OUTPUT"
-          echo "Dispatched from $BRANCH → snapshot $SNAPSHOT_TAG @ $SNAPSHOT_SHA"
+          echo "Dispatched from $BRANCH → snapshot $SNAPSHOT_TAG @ $SNAPSHOT_SHA (assets: $PROMOTE_TAG)"
 
   # ════════════════════════════════════════════════════════════════════════════
   # Create-release: open a draft release that the upload jobs append to.
@@ -126,8 +139,8 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ needs.validate.outputs.version }}
           TAG: ${{ needs.validate.outputs.tag }}
-          SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
           SNAPSHOT_SHA: ${{ needs.validate.outputs.snapshot_sha }}
+          PROMOTE_TAG: ${{ needs.validate.outputs.promote_tag }}
         run: |
           # Mark prereleases (1.2.3-rc1) as such so GitHub's "latest"
           # algorithm correctly excludes them.
@@ -143,7 +156,7 @@ jobs:
           **Version:** \`${VERSION}\`
           **Commit:** \`${SNAPSHOT_SHA}\`
 
-          Existing platform tarballs promoted from [\`${SNAPSHOT_TAG}\`](${{ github.server_url }}/${{ github.repository }}/releases/tag/${SNAPSHOT_TAG}); portable Linux tarballs built fresh from this commit.
+          Existing platform tarballs promoted from [\`${PROMOTE_TAG}\`](${{ github.server_url }}/${{ github.repository }}/releases/tag/${PROMOTE_TAG}); portable Linux tarballs built fresh from this commit.
 
           **Existing platform tarballs** (RelWithDebInfo, distro-specific):
           - \`moxygen-<platform>.tar.gz\` — stripped release build
@@ -288,17 +301,19 @@ jobs:
           app-id: ${{ secrets.OMOQ_APP_ID }}
           private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
 
-      - name: Verify snapshot hasn't been replaced mid-flight
+      # For a pinned promote source this is an integrity assert; for the
+      # pre-pinned alias fallback it is the replaced-mid-release race check.
+      - name: Verify promote source matches the resolved commit
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
-          SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
+          PROMOTE_TAG: ${{ needs.validate.outputs.promote_tag }}
           EXPECTED_SHA: ${{ needs.validate.outputs.snapshot_sha }}
         run: |
-          CURRENT_SHA=$(gh api "repos/$REPO/releases" \
-            --jq ".[] | select(.tag_name == \"$SNAPSHOT_TAG\") | .target_commitish")
+          CURRENT_SHA=$(gh api "repos/$REPO/releases/tags/$PROMOTE_TAG" \
+            --jq .target_commitish)
           if [ "$CURRENT_SHA" != "$EXPECTED_SHA" ]; then
-            echo "Error: $SNAPSHOT_TAG was replaced mid-release." >&2
+            echo "Error: $PROMOTE_TAG does not match the resolved snapshot commit." >&2
             echo "  expected: $EXPECTED_SHA" >&2
             echo "  current:  $CURRENT_SHA" >&2
             echo "Retry the dispatch — ci-main published a new snapshot during this run." >&2
@@ -309,10 +324,10 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
-          SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
+          PROMOTE_TAG: ${{ needs.validate.outputs.promote_tag }}
         run: |
           mkdir -p snapshot-assets
-          gh release download "$SNAPSHOT_TAG" --repo "$REPO" --dir snapshot-assets --pattern '*.tar.gz'
+          gh release download "$PROMOTE_TAG" --repo "$REPO" --dir snapshot-assets --pattern '*.tar.gz'
           # Drop any portable tarballs from snapshot — those are built fresh
           # in portable-build and uploaded directly there.
           rm -f snapshot-assets/moxygen-linux-amd64*.tar.gz \

--- a/openmoq/scripts/publish-artifacts.sh
+++ b/openmoq/scripts/publish-artifacts.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 # publish-artifacts.sh — Publish build artifacts as a GitHub pre-release.
 #
-# Creates (or replaces) a pre-release tagged at the given commit SHA, uploading
-# all .tar.gz files from the artifacts directory. Two tag kinds, inferred from
-# the name:
-#   snapshot-latest / snapshot-*-latest — rolling alias, replaced every push
-#   anything else (e.g. snapshot-<sha12>) — pinned snapshot, retained so
-#     pin-following consumers (moqx MOXYGEN_REV) can fetch this exact rev
+# Creates (or replaces) a pre-release tagged at the given commit SHA. Two modes:
 #
-# Usage:
-#   publish-artifacts.sh \
-#     --artifacts-dir ./release-assets \
-#     --sha <full-commit-sha>
+#   --artifacts-dir DIR   pinned snapshot (e.g. snapshot-<sha12>): uploads all
+#                         .tar.gz files; retained so pin-following consumers
+#                         (moqx MOXYGEN_REV) can fetch this exact rev
+#   --pointer-to TAG      rolling alias (snapshot-latest): asset-less release
+#                         whose notes link to the pinned release — assets are
+#                         uploaded once, to the pinned release only
+#
+# --prune-days N deletes pinned snapshot-<sha12> pre-releases (and their tags)
+# older than N days after a successful publish.
 #
 # Requires: gh CLI authenticated with a token that has contents:write.
 
@@ -24,6 +24,8 @@ SHA=""
 TAG="snapshot-latest"
 BRANCH="main"
 REPO=""  # defaults to current repo if empty
+POINTER_TO=""
+PRUNE_DAYS=0
 DRY_RUN=false
 
 # ── Argument parsing ─────────────────────────────────────────────────────────
@@ -34,10 +36,14 @@ Usage: $(basename "$0") --artifacts-dir DIR --sha SHA [OPTIONS]
 
 Options:
   --artifacts-dir DIR   Directory containing .tar.gz artifact files
+  --pointer-to TAG      Publish an asset-less pointer release linking to TAG
+                        (mutually exclusive with --artifacts-dir)
   --sha SHA             Full commit SHA for the release
   --tag TAG             Pre-release tag name (default: snapshot-latest)
   --branch BRANCH       Source branch name for release notes (default: main)
   --repo OWNER/REPO     GitHub repository (default: current repo from gh)
+  --prune-days N        After publishing, delete pinned snapshot-<sha12>
+                        pre-releases older than N days (default: 0 = off)
   --dry-run             Show what would be done without creating the release
   -h, --help            Show this help
 EOF
@@ -47,22 +53,29 @@ EOF
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --artifacts-dir) ARTIFACTS_DIR="$2"; shift 2 ;;
+    --pointer-to)    POINTER_TO="$2"; shift 2 ;;
     --sha)           SHA="$2"; shift 2 ;;
     --tag)           TAG="$2"; shift 2 ;;
     --branch)        BRANCH="$2"; shift 2 ;;
     --repo)          REPO="$2"; shift 2 ;;
+    --prune-days)    PRUNE_DAYS="$2"; shift 2 ;;
     --dry-run)       DRY_RUN=true; shift ;;
     -h|--help)       usage 0 ;;
     *)               echo "Unknown option: $1" >&2; usage 1 ;;
   esac
 done
 
-if [[ -z "$ARTIFACTS_DIR" || -z "$SHA" ]]; then
-  echo "Error: --artifacts-dir and --sha are required." >&2
+if [[ -z "$SHA" ]]; then
+  echo "Error: --sha is required." >&2
   usage 1
 fi
 
-if [[ ! -d "$ARTIFACTS_DIR" ]]; then
+if [[ -n "$ARTIFACTS_DIR" && -n "$POINTER_TO" ]] || [[ -z "$ARTIFACTS_DIR" && -z "$POINTER_TO" ]]; then
+  echo "Error: exactly one of --artifacts-dir or --pointer-to is required." >&2
+  usage 1
+fi
+
+if [[ -n "$ARTIFACTS_DIR" && ! -d "$ARTIFACTS_DIR" ]]; then
   echo "Error: artifacts directory does not exist: $ARTIFACTS_DIR" >&2
   exit 1
 fi
@@ -74,29 +87,34 @@ fi
 
 SHORT_SHA="${SHA:0:7}"
 
-# ── Step 1: Collect artifact files ───────────────────────────────────────────
+# The pointer link and the prune API need the slug even when --repo is unset.
+REPO_SLUG="${REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
 
-echo "==> Collecting artifacts from: $ARTIFACTS_DIR"
+# ── Step 1: Collect artifact files (pinned mode only) ────────────────────────
 
-# download-artifact@v4 creates a subdirectory per artifact name.
-# Flatten: find all .tar.gz files regardless of nesting depth.
 RELEASE_DIR=$(mktemp -d)
 trap 'rm -rf "$RELEASE_DIR"' EXIT
-
 ASSET_COUNT=0
-while IFS= read -r -d '' tarball; do
-  cp "$tarball" "$RELEASE_DIR/"
-  ASSET_COUNT=$((ASSET_COUNT + 1))
-  SIZE=$(du -sh "$tarball" | cut -f1)
-  echo "    $(basename "$tarball"): $SIZE"
-done < <(find "$ARTIFACTS_DIR" -name '*.tar.gz' -type f -print0)
 
-if [[ "$ASSET_COUNT" -eq 0 ]]; then
-  echo "Error: no .tar.gz files found in $ARTIFACTS_DIR" >&2
-  exit 1
+if [[ -z "$POINTER_TO" ]]; then
+  echo "==> Collecting artifacts from: $ARTIFACTS_DIR"
+
+  # download-artifact@v4 creates a subdirectory per artifact name.
+  # Flatten: find all .tar.gz files regardless of nesting depth.
+  while IFS= read -r -d '' tarball; do
+    cp "$tarball" "$RELEASE_DIR/"
+    ASSET_COUNT=$((ASSET_COUNT + 1))
+    SIZE=$(du -sh "$tarball" | cut -f1)
+    echo "    $(basename "$tarball"): $SIZE"
+  done < <(find "$ARTIFACTS_DIR" -name '*.tar.gz' -type f -print0)
+
+  if [[ "$ASSET_COUNT" -eq 0 ]]; then
+    echo "Error: no .tar.gz files found in $ARTIFACTS_DIR" >&2
+    exit 1
+  fi
+
+  echo "    Found $ASSET_COUNT artifact(s)"
 fi
-
-echo "    Found $ASSET_COUNT artifact(s)"
 
 # ── Step 2: Upload with retry ────────────────────────────────────────────────
 
@@ -129,13 +147,28 @@ case "$TAG" in
   snapshot-latest|snapshot-*-latest) ROLLING=true ;;
 esac
 
-if [[ "$ROLLING" == true ]]; then
+# Asset-bearing releases explain their tarballs; the pointer has none.
+TARBALL_FOOTER="
+
+Each platform has two tarballs:
+- \`moxygen-<platform>.tar.gz\` — stripped release build
+- \`moxygen-<platform>-dbg.tar.gz\` — split debug symbols (.debug sidecar files)"
+
+if [[ -n "$POINTER_TO" ]]; then
+  NOTES_BODY="Rolling pointer to the latest build from \`${BRANCH}\`.
+
+**Commit:** \`${SHA}\`
+**Artifacts:** [\`${POINTER_TO}\`](https://github.com/${REPO_SLUG}/releases/tag/${POINTER_TO})
+
+Updated on every push to \`${BRANCH}\`. Artifacts are uploaded once, to the
+pinned per-rev release this points at."
+elif [[ "$ROLLING" == true ]]; then
   NOTES_BODY="Rolling snapshot of the latest build from \`${BRANCH}\`.
 
 **Commit:** \`${SHA}\`
 **Built:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-This pre-release is automatically replaced on every push to \`${BRANCH}\`."
+This pre-release is automatically replaced on every push to \`${BRANCH}\`.${TARBALL_FOOTER}"
 else
   NOTES_BODY="Pinned snapshot of the build at \`${SHORT_SHA}\` (\`${BRANCH}\`).
 
@@ -143,14 +176,18 @@ else
 **Built:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 Retained so pin-following consumers (moqx \`MOXYGEN_REV\`) can fetch prebuilts
-for this exact revision."
+for this exact revision.${TARBALL_FOOTER}"
 fi
 
 echo "==> Publishing snapshot: $TAG (commit $SHORT_SHA)"
 
 if [[ "$DRY_RUN" == true ]]; then
   echo "    [dry-run] Would delete existing release $TAG"
-  echo "    [dry-run] Would create pre-release $TAG with $ASSET_COUNT assets"
+  if [[ -n "$POINTER_TO" ]]; then
+    echo "    [dry-run] Would create asset-less pointer pre-release $TAG -> $POINTER_TO"
+  else
+    echo "    [dry-run] Would create pre-release $TAG with $ASSET_COUNT assets"
+  fi
 else
   # Delete any existing release/tag with this name: replacement for rolling
   # aliases, idempotent re-publish (workflow rerun) for pinned snapshots.
@@ -173,21 +210,16 @@ else
     --target "$SHA" \
     --title "$TITLE" \
     --prerelease \
-    --notes "$(cat <<EOF
-${NOTES_BODY}
-
-Each platform has two tarballs:
-- \`moxygen-<platform>.tar.gz\` — stripped release build
-- \`moxygen-<platform>-dbg.tar.gz\` — split debug symbols (.debug sidecar files)
-EOF
-    )" \
+    --notes "$NOTES_BODY" \
     $REPO_FLAG
 
-  # Upload each asset individually with retry
-  for asset in "$RELEASE_DIR"/*.tar.gz; do
-    echo "    Uploading $(basename "$asset")..."
-    upload_with_retry "$asset"
-  done
+  # Upload each asset individually with retry (pinned mode; the pointer has none)
+  if [[ -z "$POINTER_TO" ]]; then
+    for asset in "$RELEASE_DIR"/*.tar.gz; do
+      echo "    Uploading $(basename "$asset")..."
+      upload_with_retry "$asset"
+    done
+  fi
 
   # Ensure the release is not stuck as draft
   # (gh release create without files may leave it in draft state)
@@ -200,6 +232,31 @@ EOF
   fi
 
   echo "    Snapshot published: $TAG"
+fi
+
+# ── Step 4: Prune aged pinned snapshots ──────────────────────────────────────
+
+if [[ "$PRUNE_DAYS" -gt 0 ]]; then
+  echo "==> Pruning pinned snapshots older than ${PRUNE_DAYS} days"
+  CUTOFF=$(date -u -d "-${PRUNE_DAYS} days" +%s)
+  gh api "repos/${REPO_SLUG}/releases" --paginate \
+    --jq '.[] | select(.prerelease) | [.tag_name, .created_at] | @tsv' |
+  while IFS=$'\t' read -r tag created; do
+    # Pinned snapshots only — never rolling aliases or v* releases.
+    [[ "$tag" =~ ^snapshot-[0-9a-f]{12}$ ]] || continue
+    [[ "$tag" == "$TAG" ]] && continue
+    created_s=$(date -u -d "$created" +%s)
+    if (( created_s < CUTOFF )); then
+      if [[ "$DRY_RUN" == true ]]; then
+        echo "    [dry-run] Would delete $tag (created $created)"
+      else
+        echo "    Deleting $tag (created $created)"
+        # shellcheck disable=SC2086
+        gh release delete "$tag" --yes --cleanup-tag $REPO_FLAG \
+          || echo "    WARNING: failed to delete $tag" >&2
+      fi
+    fi
+  done
 fi
 
 echo "==> Done."

--- a/openmoq/scripts/publish-artifacts.sh
+++ b/openmoq/scripts/publish-artifacts.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
-# publish-artifacts.sh — Publish build artifacts as a rolling GitHub pre-release.
+# publish-artifacts.sh — Publish build artifacts as a GitHub pre-release.
 #
-# Creates (or replaces) a `snapshot-latest` pre-release tagged at the given
-# commit SHA, uploading all .tar.gz files from the artifacts directory.
+# Creates (or replaces) a pre-release tagged at the given commit SHA, uploading
+# all .tar.gz files from the artifacts directory. Two tag kinds, inferred from
+# the name:
+#   snapshot-latest / snapshot-*-latest — rolling alias, replaced every push
+#   anything else (e.g. snapshot-<sha12>) — pinned snapshot, retained so
+#     pin-following consumers (moqx MOXYGEN_REV) can fetch this exact rev
 #
 # Usage:
 #   publish-artifacts.sh \
@@ -117,7 +121,30 @@ upload_with_retry() {
   return 1
 }
 
-# ── Step 3: Create/replace snapshot-latest ────────────────────────────────────
+# ── Step 3: Create/replace the release ───────────────────────────────────────
+
+# Rolling aliases move every push; pinned snapshots describe one rev forever.
+ROLLING=false
+case "$TAG" in
+  snapshot-latest|snapshot-*-latest) ROLLING=true ;;
+esac
+
+if [[ "$ROLLING" == true ]]; then
+  NOTES_BODY="Rolling snapshot of the latest build from \`${BRANCH}\`.
+
+**Commit:** \`${SHA}\`
+**Built:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+This pre-release is automatically replaced on every push to \`${BRANCH}\`."
+else
+  NOTES_BODY="Pinned snapshot of the build at \`${SHORT_SHA}\` (\`${BRANCH}\`).
+
+**Commit:** \`${SHA}\`
+**Built:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+Retained so pin-following consumers (moqx \`MOXYGEN_REV\`) can fetch prebuilts
+for this exact revision."
+fi
 
 echo "==> Publishing snapshot: $TAG (commit $SHORT_SHA)"
 
@@ -125,11 +152,18 @@ if [[ "$DRY_RUN" == true ]]; then
   echo "    [dry-run] Would delete existing release $TAG"
   echo "    [dry-run] Would create pre-release $TAG with $ASSET_COUNT assets"
 else
-  # Delete existing snapshot release and tag
+  # Delete any existing release/tag with this name: replacement for rolling
+  # aliases, idempotent re-publish (workflow rerun) for pinned snapshots.
   # shellcheck disable=SC2086
   gh release delete "$TAG" --yes $REPO_FLAG 2>/dev/null || true
   git tag -d "$TAG" 2>/dev/null || true
   git push origin ":refs/tags/$TAG" 2>/dev/null || true
+
+  if [[ "$ROLLING" == true ]]; then
+    TITLE="Latest build — ${BRANCH} (${SHORT_SHA})"
+  else
+    TITLE="Build — ${BRANCH} (${SHORT_SHA})"
+  fi
 
   # Create as pre-release so it doesn't show as "Latest release"
   # --target must stay an explicit sha: downstream fetchers verify
@@ -137,15 +171,10 @@ else
   # shellcheck disable=SC2086
   gh release create "$TAG" \
     --target "$SHA" \
-    --title "Latest build — ${BRANCH} (${SHORT_SHA})" \
+    --title "$TITLE" \
     --prerelease \
     --notes "$(cat <<EOF
-Rolling snapshot of the latest build from \`${BRANCH}\`.
-
-**Commit:** \`${SHA}\`
-**Built:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
-
-This pre-release is automatically replaced on every push to \`${BRANCH}\`.
+${NOTES_BODY}
 
 Each platform has two tarballs:
 - \`moxygen-<platform>.tar.gz\` — stripped release build


### PR DESCRIPTION
## Why

moqx's build now obeys its `MOXYGEN_REV` pin strictly, but our publish deletes and recreates `snapshot-latest` on every main push — so the moment the fork drifts ahead of the pin, the pinned rev has no tag, no release, no assets, and moqx falls back to a full from-source moxygen build. During the 2026-08-19 mirror/queue trouble that meant a storm of long source builds on top of everything else.

## What

Inverted from the first draft after review (a snapshot publish is ~13 GiB; duplicating it to two releases was excessive):

- **`snapshot-<sha12>` pinned pre-release carries the assets** — the one and only upload, so publish time is unchanged vs today. 12 chars matches moqx's `_rev_short` cache key. Publishes first, so a failed alias update never orphans the rev.
- **`snapshot-latest` / `snapshot-<label>-latest` become asset-less pointer releases** whose notes link to the pinned release. Safe because nothing fetches moxygen assets by alias URL: the only programmatic consumer is moqx's tag-based resolver, which picks the pinned tag whenever both point at the same commit (even before openmoq/moqx#612 — `ls-remote` sorts `snapshot-<hex>` ahead of `snapshot-latest` and the old code takes the first match).
- **30-day retention**: after each successful pinned publish, pinned snapshots older than 30 days are deleted, release and git tag both (`--prune-days 30`). Rolling aliases and `v*` releases are never touched (`^snapshot-[0-9a-f]{12}$` match). Steady state ≈ 30 revs ≈ 400 GiB and ~30 tags.
- **version-release promotes from the pinned snapshot**: `promote-snapshot` sources tarballs from `snapshot-<sha12>` (transition fallback to the alias for pre-pinned builds). Promoting from an immutable release removes the replaced-mid-flight race; the old race check becomes a plain integrity assert.

`publish-artifacts.sh` grows `--pointer-to TAG` (asset-less pointer mode, mutually exclusive with `--artifacts-dir`) and `--prune-days N`.

## Testing

Publish path is main-push only, so PR CI can't exercise it. Validated locally: pinned+prune `--dry-run` (prune correctly matched nothing against the live releases list), pointer `--dry-run`, and the mutually-exclusive-mode argument error.

## Notes

- Companion moqx PR openmoq/moqx#612 makes the pinned-tag preference explicit in the resolver; merge order between the two doesn't matter.
- Old revs published before this PR behave as before (their only tag was the rolling alias, which kept moving).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/371)
<!-- Reviewable:end -->

