### PR TITLE
github: CODEOWNERS guard on dependency pins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Pin-bump protection. Dependency pins change through upstream-sync PRs as the
+# primary path (bot-created, auto-approved by a code owner via PAT); any other
+# PR touching them needs explicit code-owner approval. Enforced by "require
+# review from Code Owners" on the main branch protection.
+/build/deps/github_hashes/ @gmarzot @michalhosna
+
+# The guard guards itself.
+/.github/CODEOWNERS @gmarzot @michalhosna


### PR DESCRIPTION
Adds `.github/CODEOWNERS` covering `build/deps/github_hashes/` (and the CODEOWNERS file itself) with @gmarzot and @michalhosna as owners.

Intent: pins flow through upstream-sync PRs as the primary path. The sync flow needs no change — sync PRs are auto-approved by the PAT identity (gmarzot, verified on recent merged sync PRs), which is a code owner, so bot bumps keep flowing. Any *other* PR touching the pins will require explicit approval from a code owner.

Enforcement activates when `require_code_owner_reviews` is flipped on the main branch protection (currently false; both repos already require 1 approving review, so non-pin PRs are unaffected). That settings change happens after this merges — companion PR in moqx guards `cmake/dependencies.cmake` (`MOXYGEN_REV`) the same way.

Caveat worth noting: a pin-touching PR *authored* by gmarzot can't be self-approved, so it would need michalhosna's approval — which is the intended behavior for manual pin overrides.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/372)
<!-- Reviewable:end -->
