### PR TITLE
collect-artifacts: compress DWARF sidecars; drop media-server binaries and .a sidecars

### DIFF
--- a/moxygen/moqtest/interop/MoQInteropClient.cpp
+++ b/moxygen/moqtest/interop/MoQInteropClient.cpp
@@ -11,6 +11,7 @@
 #include <folly/coro/Sleep.h>
 #include <folly/coro/Timeout.h>
 #include "moxygen/MoQRelaySession.h"
+#include "moxygen/MoQVersions.h"
 #include "moxygen/MoQWebTransportClient.h"
 #include "moxygen/util/InsecureVerifierDangerousDoNotUseInProduction.h"
 
@@ -102,12 +103,15 @@ class SimplePublisher : public moxygen::Publisher {
 
 namespace moxygen {
 
-// ALPN preference list, ordered highest-preference first.
-// "moq-00" is the legacy ALPN used by drafts < 15 (see kAlpnMoqtLegacy in
-// MoQVersions.h) and is what moq-rs and some other implementations offer for
-// draft-14 raw-QUIC handshakes. Including it here lets the interop client
-// negotiate with those servers.
-const std::vector<std::string> kInteropAlpns = {"moqt-16", "moqt-14", "moq-00"};
+namespace {
+void recordNegotiatedVersion(
+    InteropTestResult& result,
+    const MoQClient& client) {
+  if (client.moqSession_) {
+    result.negotiatedVersion = client.moqSession_->getNegotiatedVersion();
+  }
+}
+} // namespace
 
 MoQInteropClient::MoQInteropClient(
     folly::EventBase* evb,
@@ -115,13 +119,15 @@ MoQInteropClient::MoQInteropClient(
     bool useQuicTransport,
     bool tlsDisableVerify,
     std::chrono::milliseconds connectTimeout,
-    std::chrono::milliseconds transactionTimeout)
+    std::chrono::milliseconds transactionTimeout,
+    const std::string& versions)
     : evb_(evb),
       url_(std::move(url)),
       useQuicTransport_(useQuicTransport),
       tlsDisableVerify_(tlsDisableVerify),
       connectTimeout_(connectTimeout),
       transactionTimeout_(transactionTimeout),
+      alpns_(getMoqtProtocols(versions, /*useStandard=*/true)),
       moqExecutor_(std::make_unique<MoQFollyExecutorImpl>(evb)) {}
 
 folly::coro::Task<std::unique_ptr<MoQClient>>
@@ -143,12 +149,7 @@ MoQInteropClient::createAndSetupSession() {
   auto totalTimeout = connectTimeout_ + transactionTimeout_;
   co_await folly::coro::timeout(
       moqClient->setupMoQSession(
-          connectTimeout_,
-          transactionTimeout_,
-          nullptr,
-          nullptr,
-          ts,
-          kInteropAlpns),
+          connectTimeout_, transactionTimeout_, nullptr, nullptr, ts, alpns_),
       totalTimeout);
 
   co_return std::move(moqClient);
@@ -185,7 +186,7 @@ MoQInteropClient::createAndSetupRelaySession() {
           publishHandler,
           nullptr,
           ts,
-          kInteropAlpns),
+          alpns_),
       totalTimeout);
 
   co_return std::move(moqClient);
@@ -220,8 +221,10 @@ folly::coro::Task<InteropTestResult> MoQInteropClient::testSetupOnly() {
             nullptr, // no publish handler
             nullptr, // no subscribe handler
             ts,
-            kInteropAlpns),
+            alpns_),
         totalTimeout);
+
+    recordNegotiatedVersion(result, *moqClient);
 
     // SETUP exchange completed successfully - close gracefully
     if (moqClient->moqSession_) {
@@ -257,6 +260,7 @@ folly::coro::Task<InteropTestResult> MoQInteropClient::testAnnounceOnly() {
 
   try {
     auto moqClient = co_await createAndSetupRelaySession();
+    recordNegotiatedVersion(result, *moqClient);
 
     PublishNamespace pn;
     pn.trackNamespace = TrackNamespace({"moq-test"}, {"interop"});
@@ -297,6 +301,7 @@ folly::coro::Task<InteropTestResult> MoQInteropClient::testSubscribeError() {
 
   try {
     auto moqClient = co_await createAndSetupSession();
+    recordNegotiatedVersion(result, *moqClient);
 
     FullTrackName ftn{TrackNamespace({"nonexistent"}), "no-such-track"};
     auto sub = SubscribeRequest::make(ftn);
@@ -349,6 +354,7 @@ folly::coro::Task<InteropTestResult> MoQInteropClient::testAnnounceSubscribe() {
   try {
     // Set up publisher and announce
     publisher = co_await createAndSetupRelaySession();
+    recordNegotiatedVersion(result, *publisher);
 
     PublishNamespace pn;
     pn.trackNamespace = TrackNamespace({"moq-interop-test"});
@@ -426,6 +432,7 @@ MoQInteropClient::testPublishNamespaceDone() {
 
   try {
     auto moqClient = co_await createAndSetupRelaySession();
+    recordNegotiatedVersion(result, *moqClient);
 
     PublishNamespace pn;
     pn.trackNamespace =
@@ -477,6 +484,7 @@ MoQInteropClient::testSubscribeBeforeAnnounce() {
   try {
     // Step 1: Connect subscriber first
     subscriber = co_await createAndSetupSession();
+    recordNegotiatedVersion(result, *subscriber);
 
     FullTrackName ftn{
         TrackNamespace(std::vector<std::string>{"moq-test", "interop"}),

--- a/moxygen/moqtest/interop/MoQInteropClient.h
+++ b/moxygen/moqtest/interop/MoQInteropClient.h
@@ -9,7 +9,10 @@
 #include <folly/coro/Task.h>
 #include <proxygen/lib/utils/URL.h>
 #include <chrono>
+#include <cstdint>
+#include <optional>
 #include <string>
+#include <vector>
 #include "moxygen/MoQClient.h"
 #include "moxygen/events/MoQFollyExecutorImpl.h"
 
@@ -20,6 +23,8 @@ struct InteropTestResult {
   std::string testName;
   std::chrono::milliseconds duration{0};
   std::string message;
+  // Draft negotiated on the wire, not the one requested.
+  std::optional<uint64_t> negotiatedVersion;
 };
 
 class MoQInteropClient {
@@ -30,7 +35,8 @@ class MoQInteropClient {
       bool useQuicTransport,
       bool tlsDisableVerify,
       std::chrono::milliseconds connectTimeout,
-      std::chrono::milliseconds transactionTimeout);
+      std::chrono::milliseconds transactionTimeout,
+      const std::string& versions = "");
 
   ~MoQInteropClient() = default;
 
@@ -60,6 +66,7 @@ class MoQInteropClient {
   bool tlsDisableVerify_;
   std::chrono::milliseconds connectTimeout_;
   std::chrono::milliseconds transactionTimeout_;
+  std::vector<std::string> alpns_;
   std::shared_ptr<MoQFollyExecutorImpl> moqExecutor_;
 };
 

--- a/moxygen/moqtest/interop/MoQInteropClientMain.cpp
+++ b/moxygen/moqtest/interop/MoQInteropClientMain.cpp
@@ -4,6 +4,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <folly/String.h>
 #include <folly/coro/BlockingWait.h>
 #include <folly/init/Init.h>
 #include <folly/logging/xlog.h>
@@ -13,6 +14,7 @@
 #include <string>
 #include <vector>
 
+#include "moxygen/MoQVersions.h"
 #include "moxygen/moqtest/interop/MoQInteropClient.h"
 
 // CLI flags (also settable via environment variables)
@@ -27,6 +29,11 @@ DEFINE_bool(
     false,
     "Disable TLS certificate verification (env: TLS_DISABLE_VERIFY=1)");
 DEFINE_bool(verbose, false, "Enable verbose output (env: VERBOSE=1)");
+DEFINE_string(
+    versions,
+    "",
+    "Comma-separated MoQ draft versions (e.g. '14,16'). Empty = all "
+    "supported. (env: MOQT_VERSIONS)");
 DEFINE_int32(connect_timeout, 2000, "Connect timeout in milliseconds");
 DEFINE_int32(transaction_timeout, 2000, "Transaction timeout in milliseconds");
 
@@ -59,6 +66,13 @@ void applyEnvVarDefaults() {
     const char* verboseEnv = std::getenv("VERBOSE");
     if (verboseEnv && std::string(verboseEnv) == "1") {
       FLAGS_verbose = true;
+    }
+  }
+
+  if (FLAGS_versions.empty()) {
+    const char* versionsEnv = std::getenv("MOQT_VERSIONS");
+    if (versionsEnv && versionsEnv[0] != '\0') {
+      FLAGS_versions = versionsEnv;
     }
   }
 }
@@ -118,6 +132,11 @@ void printTapResult(
   // YAML diagnostic block
   std::cout << "  ---" << std::endl;
   std::cout << "  duration_ms: " << result.duration.count() << std::endl;
+  if (result.negotiatedVersion) {
+    std::cout << "  negotiated_version: draft-"
+              << moxygen::getDraftMajorVersion(*result.negotiatedVersion)
+              << std::endl;
+  }
   if (!result.message.empty()) {
     if (result.passed) {
       std::cout << "  info: " << result.message << std::endl;
@@ -181,6 +200,10 @@ int main(int argc, char** argv) {
   std::cout << "# Relay: " << FLAGS_relay << std::endl;
   std::cout << "# Transport: " << (useQuic ? "QUIC" : "WebTransport")
             << std::endl;
+  std::cout << "# Offered ALPNs: "
+            << folly::join(
+                   ", ", moxygen::getMoqtProtocols(FLAGS_versions, true))
+            << std::endl;
   std::cout << "1.." << testsToRun.size() << std::endl;
 
   folly::EventBase evb;
@@ -190,7 +213,8 @@ int main(int argc, char** argv) {
       useQuic,
       FLAGS_tls_disable_verify,
       std::chrono::milliseconds(FLAGS_connect_timeout),
-      std::chrono::milliseconds(FLAGS_transaction_timeout));
+      std::chrono::milliseconds(FLAGS_transaction_timeout),
+      FLAGS_versions);
 
   int failed = 0;
 

--- a/openmoq/scripts/collect-artifacts-standalone.sh
+++ b/openmoq/scripts/collect-artifacts-standalone.sh
@@ -107,8 +107,10 @@ elif [[ "$OS" == "Linux" ]]; then
     if [[ -n "$DEBUG_DIR" ]]; then
       REL="${lib#$INSTALL_PREFIX/}"
       mkdir -p "$DEBUG_DIR/$(dirname "$REL")"
-      # Extract debug sections into sidecar file
-      objcopy --only-keep-debug "$lib" "$DEBUG_DIR/${REL}.debug" 2>/dev/null || true
+      # Extract debug sections into sidecar file. Compressed DWARF (zlib,
+      # readable by gdb/elfutils) roughly halves sidecar size; the dbg
+      # tarballs were brushing GitHub's 2 GiB per-asset limit without it.
+      objcopy --only-keep-debug --compress-debug-sections "$lib" "$DEBUG_DIR/${REL}.debug" 2>/dev/null || true
     fi
     if strip --strip-debug "$lib" 2>/dev/null; then
       # Add debuglink so gdb can find the sidecar automatically
@@ -126,7 +128,7 @@ elif [[ "$OS" == "Linux" ]]; then
       if [[ -n "$DEBUG_DIR" ]]; then
         REL="${exe#$INSTALL_PREFIX/}"
         mkdir -p "$DEBUG_DIR/$(dirname "$REL")"
-        objcopy --only-keep-debug "$exe" "$DEBUG_DIR/${REL}.debug" 2>/dev/null || true
+        objcopy --only-keep-debug --compress-debug-sections "$exe" "$DEBUG_DIR/${REL}.debug" 2>/dev/null || true
       fi
       if strip --strip-debug "$exe" 2>/dev/null; then
         if [[ -n "$DEBUG_DIR" && -f "$DEBUG_DIR/${REL}.debug" ]]; then
@@ -155,6 +157,13 @@ if [[ -n "$DEBUG_OUTPUT" && -n "$DEBUG_DIR" ]]; then
     tar czf "$DEBUG_OUTPUT" -C "$DEBUG_DIR" .
     DBG_SIZE=$(du -sh "$DEBUG_OUTPUT" | cut -f1)
     echo "    Debug tarball size: $DBG_SIZE"
+    # Same 2 GiB release-asset limit as the main tarball; fail here, not at
+    # the upload step an hour later.
+    DBG_BYTES=$(stat --format=%s "$DEBUG_OUTPUT" 2>/dev/null || stat -f%z "$DEBUG_OUTPUT" 2>/dev/null)
+    if [[ "$DBG_BYTES" -ge $((2 * 1024 * 1024 * 1024)) ]]; then
+      echo "ERROR: Debug tarball exceeds GitHub Release 2 GiB limit ($DBG_SIZE)!" >&2
+      exit 1
+    fi
   else
     echo "==> No debug files extracted, skipping debug tarball"
   fi

--- a/openmoq/scripts/collect-artifacts-standalone.sh
+++ b/openmoq/scripts/collect-artifacts-standalone.sh
@@ -52,6 +52,11 @@ if [[ ! -d "$INSTALL_PREFIX" ]]; then
   exit 1
 fi
 
+# ── Step 0: Drop binaries that are not part of the relay artifact ────────────
+# The media server builds under BUILD_SAMPLES with binaries we do ship
+# (moqtest_client, relay samples), so it is excluded here rather than in CMake.
+rm -f "$INSTALL_PREFIX"/bin/moq_media_server* "$INSTALL_PREFIX"/bin/moq_mp4_receiver*
+
 # ── Step 1: Report contents ──────────────────────────────────────────────────
 
 echo "==> Install prefix: $INSTALL_PREFIX"
@@ -81,7 +86,10 @@ fi
 
 if [[ "$OS" == "Darwin" ]]; then
   while IFS= read -r -d '' lib; do
-    if [[ -n "$DEBUG_DIR" ]]; then
+    # No sidecars for static archives: their DWARF is already in every
+    # executable that links them, and nothing debugs a .a — the sidecars
+    # only doubled the dbg tarball.
+    if [[ -n "$DEBUG_DIR" && "$lib" != *.a ]]; then
       REL="${lib#$INSTALL_PREFIX/}"
       mkdir -p "$DEBUG_DIR/$(dirname "$REL")"
       # macOS: copy unstripped lib as debug sidecar (no objcopy equivalent)
@@ -104,8 +112,11 @@ if [[ "$OS" == "Darwin" ]]; then
 
 elif [[ "$OS" == "Linux" ]]; then
   while IFS= read -r -d '' lib; do
-    if [[ -n "$DEBUG_DIR" ]]; then
-      REL="${lib#$INSTALL_PREFIX/}"
+    REL="${lib#$INSTALL_PREFIX/}"
+    # No sidecars for static archives: their DWARF is already in every
+    # executable that links them, and nothing debugs a .a — the sidecars
+    # only doubled the dbg tarball.
+    if [[ -n "$DEBUG_DIR" && "$lib" != *.a ]]; then
       mkdir -p "$DEBUG_DIR/$(dirname "$REL")"
       # Extract debug sections into sidecar file. Compressed DWARF (zlib,
       # readable by gdb/elfutils) roughly halves sidecar size; the dbg

--- a/openmoq/scripts/collect-artifacts-standalone.sh
+++ b/openmoq/scripts/collect-artifacts-standalone.sh
@@ -53,8 +53,7 @@ if [[ ! -d "$INSTALL_PREFIX" ]]; then
 fi
 
 # ── Step 0: Drop binaries that are not part of the relay artifact ────────────
-# The media server builds under BUILD_SAMPLES with binaries we do ship
-# (moqtest_client, relay samples), so it is excluded here rather than in CMake.
+# Built under BUILD_SAMPLES beside binaries we do ship, so excluded here.
 rm -f "$INSTALL_PREFIX"/bin/moq_media_server* "$INSTALL_PREFIX"/bin/moq_mp4_receiver*
 
 # ── Step 1: Report contents ──────────────────────────────────────────────────
@@ -86,9 +85,7 @@ fi
 
 if [[ "$OS" == "Darwin" ]]; then
   while IFS= read -r -d '' lib; do
-    # No sidecars for static archives: their DWARF is already in every
-    # executable that links them, and nothing debugs a .a — the sidecars
-    # only doubled the dbg tarball.
+    # No .a sidecars — see the Linux loop.
     if [[ -n "$DEBUG_DIR" && "$lib" != *.a ]]; then
       REL="${lib#$INSTALL_PREFIX/}"
       mkdir -p "$DEBUG_DIR/$(dirname "$REL")"
@@ -113,14 +110,11 @@ if [[ "$OS" == "Darwin" ]]; then
 elif [[ "$OS" == "Linux" ]]; then
   while IFS= read -r -d '' lib; do
     REL="${lib#$INSTALL_PREFIX/}"
-    # No sidecars for static archives: their DWARF is already in every
-    # executable that links them, and nothing debugs a .a — the sidecars
-    # only doubled the dbg tarball.
+    # No .a sidecars: every executable that links an archive already carries
+    # its DWARF, and nothing debugs a .a.
     if [[ -n "$DEBUG_DIR" && "$lib" != *.a ]]; then
       mkdir -p "$DEBUG_DIR/$(dirname "$REL")"
-      # Extract debug sections into sidecar file. Compressed DWARF (zlib,
-      # readable by gdb/elfutils) roughly halves sidecar size; the dbg
-      # tarballs were brushing GitHub's 2 GiB per-asset limit without it.
+      # Compressed DWARF (zlib, gdb/elfutils-readable) halves sidecar size.
       objcopy --only-keep-debug --compress-debug-sections "$lib" "$DEBUG_DIR/${REL}.debug" 2>/dev/null || true
     fi
     if strip --strip-debug "$lib" 2>/dev/null; then
@@ -168,8 +162,7 @@ if [[ -n "$DEBUG_OUTPUT" && -n "$DEBUG_DIR" ]]; then
     tar czf "$DEBUG_OUTPUT" -C "$DEBUG_DIR" .
     DBG_SIZE=$(du -sh "$DEBUG_OUTPUT" | cut -f1)
     echo "    Debug tarball size: $DBG_SIZE"
-    # Same 2 GiB release-asset limit as the main tarball; fail here, not at
-    # the upload step an hour later.
+    # Same 2 GiB release-asset limit as the main tarball.
     DBG_BYTES=$(stat --format=%s "$DEBUG_OUTPUT" 2>/dev/null || stat -f%z "$DEBUG_OUTPUT" 2>/dev/null)
     if [[ "$DBG_BYTES" -ge $((2 * 1024 * 1024 * 1024)) ]]; then
       echo "ERROR: Debug tarball exceeds GitHub Release 2 GiB limit ($DBG_SIZE)!" >&2


### PR DESCRIPTION
Fixes the release-job failure on last night's push (run 32450638169): four `-dbg` tarballs crossed GitHub's **2 GiB per-release-asset limit**, `gh release upload` fails with HTTP 422, `snapshot-f8840755e47c` published with zero assets, and moqx CI is on from-source fallback until the next good publish + sync.

What pushed it over: the upstream sync added the two MoQMediaServer binaries (`moq_media_server`, `moq_mp4_receiver`), each a statically-linked executable carrying its own full copy of folly/proxygen DWARF — and the largest dbg tarball was already at 97% of the limit.

## Changes (all in `collect-artifacts-standalone.sh`, covering ci-main platform tarballs and version-release portable tarballs)

1. **Compress DWARF in sidecars** — `objcopy --only-keep-debug --compress-debug-sections`. gdb/elfutils read zlib-compressed sections natively; verified locally through the full objcopy → strip → debuglink → gdb pipeline. Roughly halves sidecar size.
2. **Drop the media-server binaries from the artifact** — nothing consuming the relay artifact uses them (they arrived yesterday). They build under `BUILD_SAMPLES` beside binaries we do ship (`moqtest_client`, relay samples), so exclusion happens at packaging, not CMake.
3. **Drop static-archive (.a) debug sidecars** — verified no consumer: moqx has zero references to dbg tarballs; the documented debug use case (folly::symbolizer against the sidecar) is executable sidecars, which remain. Every executable already carries the archives' DWARF, and the shipped `.a` files were already stripped, so downstream static linking is byte-for-byte unchanged.
4. **2 GiB check now covers the debug tarball too** — the next size problem fails in the publish build with a clear message, not at the upload an hour later.

Expected effect: dbg tarballs go from 2.0–2.3 GiB to well under 1 GiB (executables only, compressed DWARF), and per-publish retention footprint drops accordingly. Exact numbers will show in the first main-push run.

Verified against a synthetic install prefix: media-server binaries absent from both tarballs, `.a` present and stripped in the main tarball, no `.a` sidecars, executable sidecar intact with working debuglink.

Publish path is main-push only, so PR CI can't exercise it; the first main push after merge is the real test and re-publishes a good pinned snapshot for moqx.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/374)
<!-- Reviewable:end -->
