### PR TITLE
Gate the media server out of the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,11 @@ option(BUILD_MOQTEST
   ON
 )
 
+option(BUILD_MEDIA_SERVER
+  "If enabled, build the media server and mp4 receiver executables."
+  ON
+)
+
 list(APPEND
   _MOXYGEN_COMMON_COMPILE_OPTIONS
   -Wall

--- a/moxygen/CMakeLists.txt
+++ b/moxygen/CMakeLists.txt
@@ -343,8 +343,11 @@ if(BUILD_SAMPLES OR BUILD_MOQTEST)
 endif()
 
 if(BUILD_SAMPLES)
-  add_subdirectory(media_server)
   add_subdirectory(samples)
+endif()
+
+if(BUILD_MEDIA_SERVER)
+  add_subdirectory(media_server)
 endif()
 
 if(BUILD_MOQTEST)

--- a/openmoq/scripts/collect-artifacts-standalone.sh
+++ b/openmoq/scripts/collect-artifacts-standalone.sh
@@ -52,10 +52,6 @@ if [[ ! -d "$INSTALL_PREFIX" ]]; then
   exit 1
 fi
 
-# ── Step 0: Drop binaries that are not part of the relay artifact ────────────
-# Built under BUILD_SAMPLES beside binaries we do ship, so excluded here.
-rm -f "$INSTALL_PREFIX"/bin/moq_media_server* "$INSTALL_PREFIX"/bin/moq_mp4_receiver*
-
 # ── Step 1: Report contents ──────────────────────────────────────────────────
 
 echo "==> Install prefix: $INSTALL_PREFIX"


### PR DESCRIPTION
Fixes the moqx sync failure on `sync-moxygen/008ee8e`.

## What broke

`collect-artifacts-standalone.sh` deleted `moq_media_server` and `moq_mp4_receiver` from `bin/` after install — they are built under `BUILD_SAMPLES` and are not part of the relay artifact. But moxygen installs every executable into `moxygen-exports`, so the imported targets stayed in `moxygen-targets.cmake` pointing at files that no longer existed. Any consumer calling `find_package(moxygen)` failed:

```
CMake Error at .../lib/cmake/moxygen/moxygen-targets.cmake:677 (message):
  The imported target "moxygen::moq_media_server" references the file
     ".../bin/moq_media_server"
  but this file does not exist.
```

It was masked at `91f2387`, where `BUILD_SAMPLES` was accidentally off — the media server was never built there, and that tarball has zero references to it. Restoring the option in #376 brought the targets back and the next sync went red.

## The fix

Deleting files after install cannot work while those files are exported — the export always wins. So the directory is gated out of the build instead: nothing is built, nothing is installed, nothing is exported, and the post-install deletion is removed.

`BUILD_MEDIA_SERVER` follows `BUILD_MOQTEST` exactly: declared in the root `CMakeLists.txt`, defaulting on, so getdeps and full-repo builds are unchanged. The standalone build does not process that file, so the option is undefined there and the directory drops out — the same mechanism `BUILD_SAMPLES` already relies on, which means there is no fork-local declaration for a sync to lose.

`add_subdirectory(media_server)` moves out from under `if(BUILD_SAMPLES)` into its own gate. Nothing outside `moxygen/media_server` links its targets.

## Verification

Configured `standalone`:

- no `media_server`, `moq_media_server` or `moq_mp4_receiver` targets exist
- `moqdateserver`, `moqtextclient`, `moqtest_server`, `moqtest_client` and `moqperf_test_client` still build

Before settling on this, the earlier post-install approach was tested end to end — packaging a prefix seeded with both binaries and configuring a consumer against the resulting tarball, which reproduced the error on the unpruned tarball and passed on the pruned one. That work is dropped in favour of the build-time gate, which removes the problem rather than repairing its output.

## Note

This is the same shape as `BUILD_MOQTEST` and is worth offering upstream, so the fork does not carry the gate alone.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/379)
<!-- Reviewable:end -->
