### PR TITLE
Prune superseded build caches on main

### DIFF
--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -346,6 +346,63 @@ jobs:
   # Notify: aggregate status (runs after everything)
   # ════════════════════════════════════════════════════════════════════════════
 
+  # ════════════════════════════════════════════════════════════════════════════
+  # Prune build caches: keep the newest generation of each cache family.
+  #
+  # Both cache kinds mint a new entry rather than replacing one — the dep key
+  # hashes the pin files, and ccache-action keys on a timestamp. Keeping one
+  # generation each holds the repo near the 10 GB budget, where eviction would
+  # otherwise drop main's caches and leave every PR restoring nothing.
+  # ════════════════════════════════════════════════════════════════════════════
+
+  prune-caches:
+    needs: [build, publish]
+    if: always() && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: write
+    steps:
+      # Runs after build and publish so this run's caches are already saved and
+      # are the generation kept.
+      - name: Delete superseded generations
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          cat > family.jq <<'JQ'
+          # Family = the key without its varying suffix: dep caches end in
+          # -deps-<hash>, ccache-action keys end in -<ISO timestamp>.
+          def family:
+            if (.key | test("-deps-")) then
+              (.key | capture("^(?<p>.*-deps)-").p)
+            elif (.key | test("-[0-9]{4}-[0-9]{2}-[0-9]{2}T")) then
+              (.key | capture("^(?<p>.*)-[0-9]{4}-[0-9]{2}-[0-9]{2}T").p)
+            else null end;
+          map(select(family != null))
+          | group_by(family)
+          | map(sort_by(.createdAt) | reverse | .[1:])
+          | flatten
+          | .[] | "\(.id)\t\(.sizeInBytes)\t\(.key)"
+          JQ
+
+          gh cache list --ref refs/heads/main --limit 100 \
+            --json id,key,sizeInBytes,createdAt > caches.json
+          jq -r -f family.jq caches.json > stale.tsv
+
+          if [ ! -s stale.tsv ]; then
+            echo "==> nothing superseded"
+            exit 0
+          fi
+
+          FREED=0
+          while IFS=$'\t' read -r id size key; do
+            echo "  deleting $key ($((size / 1048576)) MB)"
+            if gh cache delete "$id"; then
+              FREED=$((FREED + size))
+            fi
+          done < stale.tsv
+          echo "==> freed $((FREED / 1048576)) MB"
+
   notify:
     needs: [build, publish, release]
     if: always()

--- a/.github/workflows/omoq-ci-main.yml
+++ b/.github/workflows/omoq-ci-main.yml
@@ -11,7 +11,8 @@ name: ci main
 # Job graph:
 #
 #   build (linux, macos, asan debug) ─────────────────────────────────────────┐
-#   publish (3 platforms) ───────────────────────────────────────────────────┼── release ── notify
+#   publish (7 platforms) ───────────────────────────────────────────────────┼── release ── notify
+#                                                                            └── prune-caches
 
 on:
   push:
@@ -343,10 +344,6 @@ jobs:
             --branch "${{ github.ref_name }}"
 
   # ════════════════════════════════════════════════════════════════════════════
-  # Notify: aggregate status (runs after everything)
-  # ════════════════════════════════════════════════════════════════════════════
-
-  # ════════════════════════════════════════════════════════════════════════════
   # Prune build caches: keep the newest generation of each cache family.
   #
   # Both cache kinds mint a new entry rather than replacing one — the dep key
@@ -357,7 +354,7 @@ jobs:
 
   prune-caches:
     needs: [build, publish]
-    if: always() && github.ref == 'refs/heads/main'
+    if: always() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))
     runs-on: ubuntu-22.04
     permissions:
       actions: write
@@ -385,7 +382,7 @@ jobs:
           | .[] | "\(.id)\t\(.sizeInBytes)\t\(.key)"
           JQ
 
-          gh cache list --ref refs/heads/main --limit 100 \
+          gh cache list --ref "$GITHUB_REF" --limit 100 \
             --json id,key,sizeInBytes,createdAt > caches.json
           jq -r -f family.jq caches.json > stale.tsv
 
@@ -402,6 +399,10 @@ jobs:
             fi
           done < stale.tsv
           echo "==> freed $((FREED / 1048576)) MB"
+
+  # ════════════════════════════════════════════════════════════════════════════
+  # Notify: aggregate status (runs after everything)
+  # ════════════════════════════════════════════════════════════════════════════
 
   notify:
     needs: [build, publish, release]


### PR DESCRIPTION
Draft — the numbers are measured, but this deletes caches, so it wants a look
before it runs.

Implements #381, and covers one thing that issue missed.

## What accumulates

Both cache kinds mint a new entry per run rather than replacing one:

- dep caches key on `hashFiles('build/deps/github_hashes/**')`, so every pin
  change makes a fresh ~1.3 GB entry per platform
- `ccache-action` keys on a **timestamp**, so every run makes a fresh ~500 MB
  entry per lane. `max-size: 500M` bounds each entry, not how many exist

#381 only described the dep half. The ccache half is about the same size.

## Measured effect

Against the live cache list for `main` (36 entries, 25.7 GB), keeping the newest
generation of each family selects **16 entries, 12.5 GB**:

```
 8 ccache generations   ~3.9 GB   (one per lane, previous run)
 8 dep generations      ~8.7 GB   (one per platform, previous pin)
```

That takes the repo from 25.7 GB to **13.5 GB**.

## It does not get us under the limit

13.5 GB is still above GitHub's 10 GB, so eviction continues, just more slowly.
Closing the rest needs a policy call rather than more pruning — the candidates are
dropping dep caches for the sanitizer publish lanes (~2.6 GB), lowering ccache
`max-size`, or caching fewer publish platforms. Worth deciding separately; this
change is worth having either way.

## How it works

A `prune-caches` job after `build` and `publish`, `main` only, `actions: write`.
It runs after those jobs so this run's caches are already saved and are the
generation kept. `if: always()` so a red build still gets pruned — a failed run
should not also leave the budget blown.

Family is the key minus its varying suffix, handling both shapes.

## Verifying

`gh cache delete` cannot be rehearsed, but everything up to it was run against
live data:

- the jq extracted verbatim from the workflow selects 16 entries / 12,507 MB,
  identical to the prototype
- the selection is exactly one superseded generation per family — no newest
  generation and no unrecognized key is ever chosen
- the `IFS=$'\t' read` loop parses all 16 rows and totals correctly
- the heredoc terminator resolves to column 0 after YAML block-scalar parsing

The first real run should log `==> freed 12507 MB` or close to it, and the repo's
cache usage should drop to ~13.5 GB.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moxygen/383)
<!-- Reviewable:end -->
